### PR TITLE
Add introduction to group theory LaTeX file

### DIFF
--- a/introduction_to_group_theory.tex
+++ b/introduction_to_group_theory.tex
@@ -1,0 +1,28 @@
+\documentclass{article}
+\usepackage{amsmath,amssymb}
+
+\title{Introduction to Group Theory}
+\author{}
+\date{}
+
+\begin{document}
+\maketitle
+
+\section{Groups}
+A \emph{group} $(G,\cdot)$ consists of a set $G$ equipped with a binary operation $\cdot$ such that the following axioms hold:
+\begin{enumerate}
+  \item \textbf{Associativity:} $(a\cdot b)\cdot c = a\cdot(b\cdot c)$ for all $a,b,c\in G$.
+  \item \textbf{Identity:} There exists an element $e\in G$ such that $e\cdot a = a\cdot e = a$ for all $a\in G$.
+  \item \textbf{Inverse:} For each $a\in G$ there exists $b\in G$ such that $a\cdot b = b\cdot a = e$.
+\end{enumerate}
+
+\section{Examples}
+\begin{itemize}
+  \item The integers $(\mathbb{Z}, +)$ form a group under addition with identity element $0$.
+  \item The set of $n\times n$ invertible real matrices $\mathrm{GL}_n(\mathbb{R})$ is a group under matrix multiplication.
+  \item The symmetric group $S_3$ consists of all permutations of three objects.
+\end{itemize}
+
+\section{Subgroups}
+A \emph{subgroup} $H$ of a group $G$ is a subset of $G$ that is itself a group under the operation of $G$.
+\end{document}

--- a/introduction_to_group_theory.tex
+++ b/introduction_to_group_theory.tex
@@ -1,226 +1,196 @@
 \documentclass[12pt]{article}
 \usepackage{amsmath,amssymb,amsfonts}
 \usepackage{xcolor}
-\usepackage{tcolorbox}
 \usepackage{hyperref}
-\tcbset{colback=white,colframe=black}
-\newtcolorbox{definitionbox}[1]{colback=blue!5!white,colframe=blue!75!black,title=\textbf{#1}}
-\newtcolorbox{examplebox}[1]{colback=green!5!white,colframe=green!60!black,title=\textbf{#1}}
-\newtcolorbox{warnbox}[1]{colback=red!5!white,colframe=red!60!black,title=\textbf{#1}}
 
-\title{From Zero to Lagrange\\\small A Friendly Introduction to Group Theory}
+\title{From Zero to Lagrange\\\small Lecture Notes on Group Theory}
 \author{}
 \date{}
 
 \begin{document}
 \maketitle
 
-\section*{Introduction: What You Need}
-\begin{definitionbox}{Starting Point}
-To talk about groups, you begin with:
-\begin{itemize}
-  \item a set $G$,
-  \item a binary rule $\star$ that takes $a,b$ in $G$ and returns $a\star b$ in $G$,
-  \item four checks: \textcolor{blue}{closure}, \textcolor{blue}{associativity}, \textcolor{blue}{identity}, and \textcolor{blue}{inverses}.
-\end{itemize}
-\end{definitionbox}
+\section*{1. Getting Started}
+To study groups we need a set $G$ together with a way to combine any two of its elements.
+Throughout these notes the operation will be denoted by $\star$.
+Before calling $(G,\star)$ a \textcolor{blue}{group} we must check four requirements: \textcolor{blue}{closure}, \textcolor{blue}{associativity}, the presence of an \textcolor{blue}{identity} element, and the existence of \textcolor{blue}{inverses}.
 
-\section*{Definition: Group}
-\begin{definitionbox}{What is a Group?}
-A pair $(G,\star)$ is a \textcolor{blue}{group} if for all $a,b,c\in G$:
+\section*{2. Definition of a Group}
+\textcolor{blue}{\textbf{Definition.}} A pair $(G,\star)$ is a group if for all $a,b,c\in G$:
 \begin{enumerate}
-  \item \textbf{Closure:} $a\star b$ is in $G$.
+  \item \textbf{Closure:} $a\star b$ lies in $G$.
   \item \textbf{Associativity:} $(a\star b)\star c = a\star(b\star c)$.
-  \item \textbf{Identity:} there exists $e$ with $e\star a = a\star e = a$.
-  \item \textbf{Inverse:} each $a$ has $a^{-1}$ with $a\star a^{-1} = a^{-1}\star a = e$.
+  \item \textbf{Identity:} there exists $e\in G$ with $e\star a=a\star e=a$ for every $a$.
+  \item \textbf{Inverses:} each $a$ has $a^{-1}$ in $G$ such that $a\star a^{-1}=a^{-1}\star a=e$.
 \end{enumerate}
-The group is \textcolor{purple}{abelian} if $a\star b = b\star a$ for all $a,b$.
-\end{definitionbox}
+If $a\star b=b\star a$ for all $a,b$, the group is called \textcolor{purple}{abelian}.
 
-\section*{How to Prove ``This is a Group"}
-\begin{examplebox}{Group Proof Recipe}
-\begin{enumerate}
-  \item Describe $G$ and the operation $\star$.
-  \item Show \textcolor{blue}{closure}.
-  \item Use known \textcolor{blue}{associativity} (for $+$ or $\times$) or compute directly.
-  \item Give the \textcolor{blue}{identity} element.
-  \item For any $a$, find $a^{-1}$ and check it works.
-\end{enumerate}
-\end{examplebox}
+\section*{3. Verifying a Group}
+When presenting a new structure, begin by describing the set and the operation.
+Check closure by combining generic elements, appeal to known associativity when possible, identify the element that leaves others unchanged, and finally produce an inverse for a typical element.
 
-\section*{Worked Examples: Groups and Non-Examples}
-\begin{examplebox}{1. $(\mathbb{Z}, +)$}
-Closure: $m+n$ is an integer. Identity: $0$. Inverse of $m$ is $-m$. This group is abelian.
-\end{examplebox}
+\section*{4. Examples and Non-examples}
+\subsection*{Example: $(\mathbb{Z},+)$}
+Given integers $m$ and $n$, their sum $m+n$ is an integer, so the set is closed under addition.
+Addition of integers is associative, $0$ acts as the identity, and $m+(-m)=0$ shows that $-m$ is the inverse of $m$.
+The operation is commutative, hence $\mathbb{Z}$ is abelian.
 
-\begin{examplebox}{2. $(\mathbb{Z}_n, +\ \text{mod}\ n)$}
-Elements: $\{0,1,\dots,n-1\}$. Operation: addition mod $n$. Identity: $0$. Inverse of $k$ is $n-k$. Abelian.
-\textit{Example:} in $\mathbb{Z}_6$, $4+5\equiv3$ and the inverse of $4$ is $2$.
-\end{examplebox}
+\subsection*{Example: $(\mathbb{Z}_n,+ \text{ mod } n)$}
+The set $\mathbb{Z}_n=\{0,1,\ldots,n-1\}$ is closed under addition modulo $n$.
+For instance in $\mathbb{Z}_6$,
+\[
+4+5=9\equiv 3 \pmod 6.
+\]
+The class $0$ serves as identity and the inverse of $k$ is $n-k$.
 
-\begin{examplebox}{3. $(\mathbb{Q}^*,\times)$ and $(\mathbb{R}^*,\times)$}
-Identity: $1$. Inverse of $a/b$ is $b/a$. Both are abelian.
-\end{examplebox}
+\subsection*{Example: $(\mathbb{Q}^*,\times)$ and $(\mathbb{R}^*,\times)$}
+Multiplication of nonzero rationals or reals is associative and closed.
+The number $1$ is the identity and the inverse of $\frac{a}{b}$ is $\frac{b}{a}$.
+Both groups are abelian.
 
-\begin{examplebox}{4. $\mathrm{GL}_2(\mathbb{R})$}
-$2\times2$ invertible real matrices under multiplication. Identity is $I=\begin{bmatrix}1&0\\0&1\end{bmatrix}$. Inverses are usual matrix inverses. Generally non-abelian. For example,\[\begin{bmatrix}1&1\\0&1\end{bmatrix}\begin{bmatrix}1&0\\1&1\end{bmatrix}=\begin{bmatrix}2&1\\1&1\end{bmatrix} \neq \begin{bmatrix}1&0\\1&1\end{bmatrix}\begin{bmatrix}1&1\\0&1\end{bmatrix}=\begin{bmatrix}1&1\\1&2\end{bmatrix}.\]
-\end{examplebox}
+\subsection*{Example: $\mathrm{GL}_2(\mathbb{R})$}
+This group consists of all invertible $2\times2$ real matrices under multiplication.
+Closure follows because the product of invertible matrices is invertible.
+For
+\[
+A=\begin{bmatrix}1&1\\0&1\end{bmatrix},\quad
+B=\begin{bmatrix}1&0\\1&1\end{bmatrix},
+\]
+we compute
+\[
+AB=\begin{bmatrix}2&1\\1&1\end{bmatrix},\qquad
+BA=\begin{bmatrix}1&1\\1&2\end{bmatrix},
+\]
+so $AB\neq BA$ and the group is not abelian.
 
-\begin{examplebox}{5. Symmetric Group $S_3$}
-Six permutations of $\{1,2,3\}$ with composition. Non-abelian: $(12)\circ(23) \neq (23)\circ(12)$. Example: $(12)(23)=(123)$.
-\end{examplebox}
+\subsection*{Example: Symmetric Group $S_3$}
+$S_3$ contains the six permutations of $\{1,2,3\}$.
+Composition of permutations is associative and the identity map fixes each number.
+The permutation $(12)(23)$ sends $1\mapsto2\mapsto3$, $2\mapsto3\mapsto1$, and $3\mapsto1\mapsto2$, giving $(123)$.
+Because $(12)(23)\neq(23)(12)$ the group is non-abelian.
 
-\begin{examplebox}{6. Dihedral Group $D_4$}
-Symmetries of a square: four rotations and four reflections. Non-abelian.
-\end{examplebox}
+\subsection*{Example: Dihedral Group $D_4$}
+$D_4$ records symmetries of a square: four rotations and four reflections.
+Rotation by $90^{\circ}$ composed four times returns the square to its original position, while reflections reverse orientation; the operation is composition of these symmetries.
+The group fails to be abelian because, for example, reflecting then rotating is different from rotating then reflecting.
 
-\begin{examplebox}{7. Klein Four Group $V_4$}
-Elements $\{e,a,b,c\}$ with $a^2=b^2=c^2=e$ and $ab=c$, $bc=a$, $ca=b$. Abelian but not cyclic.
-\end{examplebox}
+\subsection*{Example: Klein Four Group $V_4$}
+The set $\{e,a,b,c\}$ with relations $a^2=b^2=c^2=e$ and $ab=c$, $bc=a$, $ca=b$ forms a group.
+Each element is its own inverse and the operation is commutative, but no single element generates the entire group.
 
-\begin{warnbox}{Non-Examples}
+\subsection*{Non-examples}
+The natural numbers under addition lack inverses, the integers under multiplication lack inverses for most elements, and real numbers with subtraction violate associativity.
+
+\section*{5. Fundamental Notions}
+The \textcolor{blue}{order} of an element $a$ is the smallest positive integer $k$ with $a^k=e$ (or $k\cdot a=0$ in additive notation).
+A group is \textcolor{blue}{cyclic} if one element generates all others: $G=\langle g\rangle=\{\ldots,g^{-1},e,g,g^{2},\ldots\}$.
+The \textcolor{blue}{order of the group} is the number of elements it contains.
+
+\section*{6. Subgroups}
+\textcolor{blue}{\textbf{Definition.}} A nonempty subset $H$ of $G$ is a subgroup, written $H\leq G$, if for all $a,b\in H$ the element $ab^{-1}$ also lies in $H$.
+In additive groups we test closure under subtraction.
+
+\subsection*{Useful Facts}
 \begin{itemize}
-  \item $(\mathbb{N},+)$ fails inverses.
-  \item $(\mathbb{Z},\times)$ fails inverses for most elements.
-  \item $(\mathbb{R},-)$ fails associativity.
-\end{itemize}
-\end{warnbox}
-
-\section*{Basic Concepts You Will Use Soon}
-\begin{definitionbox}{Key Ideas}
-\begin{itemize}
-  \item \textbf{Order of an element} $a$: smallest $k>0$ with $a^k=e$ (or $k\cdot a=0$ in additive groups).
-  \item \textbf{Cyclic group:} a group generated by one element $g$.
-  \item \textbf{Order of a group:} number of elements $|G|$ if finite.
-\end{itemize}
-\end{definitionbox}
-
-\section*{Subgroups}
-\begin{definitionbox}{What is a Subgroup?}
-A nonempty subset $H$ of $G$ is a \textcolor{blue}{subgroup} if for all $a,b\in H$, the element $a\star b^{-1}$ is also in $H$. For additive groups replace $a\star b^{-1}$ by $a-b$.
-\end{definitionbox}
-
-\subsection*{Quick Subgroup Facts}
-\begin{itemize}
-  \item The identity $e$ lies in every subgroup.
+  \item The identity of $G$ is always in $H$.
   \item If $a\in H$ then $a^{-1}\in H$.
   \item Intersections of subgroups are subgroups.
-  \item The subgroup generated by $S$ is $\langle S\rangle$.
+  \item The subgroup generated by a set $S$ is the smallest subgroup containing $S$ and is denoted $\langle S\rangle$.
 \end{itemize}
 
-\subsection*{Worked Examples: Subgroups}
-\begin{examplebox}{1. $k\mathbb{Z} \leq \mathbb{Z}$}
-$k\mathbb{Z}=\{\ldots,-2k,-k,0,k,2k,\ldots\}$ is closed under subtraction, so it is a subgroup. Examples include even integers $2\mathbb{Z}$.
-\end{examplebox}
+\subsection*{Examples}
+\paragraph{1. $k\mathbb{Z}$ inside $\mathbb{Z}$.}
+For an integer $k$, the set $k\mathbb{Z}=\{\ldots,-2k,-k,0,k,2k,\ldots\}$ is closed under subtraction, hence forms a subgroup.
 
-\begin{examplebox}{2. Subgroups of $\mathbb{Z}_6$ under $+$}
-Every subgroup is $\langle d\rangle$ where $d$ divides $6$. They are $\{0\}$, $\{0,3\}$, $\{0,2,4\}$, and $\mathbb{Z}_6$. The subset $T=\{0,2\}$ fails because $2+2=4\notin T$.
-\end{examplebox}
+\paragraph{2. Subgroups of $\mathbb{Z}_6$.}
+Every subgroup is generated by a divisor of $6$:
+\[
+\{0\},\quad \{0,3\},\quad \{0,2,4\},\quad \mathbb{Z}_6.
+\]
+The subset $\{0,2\}$ is not a subgroup since $2+2=4\notin\{0,2\}$.
 
-\begin{examplebox}{3. Subgroups of $S_3$}
-Possible sizes: $1,2,3,6$. Subgroups: $\{e\}$; three generated by transpositions $\langle(12)\rangle$, $\langle(13)\rangle$, $\langle(23)\rangle$; the order-3 subgroup $A_3=\langle(123)\rangle$; and $S_3$ itself.
-\end{examplebox}
+\paragraph{3. Subgroups of $S_3$.}
+They have sizes $1,2,3,$ or $6$.
+Besides the trivial subgroup and $S_3$ itself, there are three subgroups generated by transpositions and a three-element subgroup $\{e,(123),(132)\}$.
 
-\begin{examplebox}{4. Center $Z(G)$}
-$Z(G)=\{g\in G: gx=xg \text{ for all } x\in G\}$ is a subgroup.
-\end{examplebox}
+\paragraph{4. The center $Z(G)$.}
+$Z(G)=\{g\in G: gx=xg \text{ for all } x\in G\}$ is a subgroup because products and inverses of commuting elements also commute.
 
-\begin{examplebox}{5. Rotation Subgroup of $D_4$}
-$R=\{e,r,r^2,r^3\}$ with $r$ a $90^\circ$ rotation is a subgroup of order $4$.
-\end{examplebox}
+\paragraph{5. Rotations in $D_4$.}
+The set $\{e,r,r^2,r^3\}$ of rotations is a subgroup of order $4$.
 
-\begin{examplebox}{6. Upper Triangular Matrices}
-Invertible upper triangular matrices form a subgroup of $\mathrm{GL}_2(\mathbb{R})$.
-\end{examplebox}
+\paragraph{6. Upper triangular matrices.}
+The invertible upper triangular matrices form a subgroup of $\mathrm{GL}_2(\mathbb{R})$ since the product and inverse of such matrices remain upper triangular.
 
-\section*{Cosets and Index}
-\begin{definitionbox}{Cosets}
-For $H\leq G$ and $g\in G$:
+\section*{7. Cosets and Index}
+Given $H\leq G$ and $g\in G$, the \textcolor{blue}{left coset} $gH$ is $\{gh:h\in H\}$ and the \textcolor{blue}{right coset} $Hg$ is $\{hg:h\in H\}$.
+All cosets have the same size as $H$; two cosets are either identical or disjoint, and the left cosets partition $G$.
+The number of distinct left cosets is called the \textcolor{blue}{index} and is written $[G:H]$.
+
+\subsection*{Examples}
+\paragraph{$\mathbb{Z}_6$ with $H=\{0,3\}$.}
+The cosets are
+\[
+0+H=\{0,3\},\quad 1+H=\{1,4\},\quad 2+H=\{2,5\},
+\]
+so $[\mathbb{Z}_6:H]=3$.
+
+\paragraph{$S_3$ with $H=\langle(12)\rangle$.}
+We obtain three cosets:
+\[
+H=\{e,(12)\},\quad (13)H=\{(13),(132)\},\quad (23)H=\{(23),(123)\}.
+\]
+Each coset has two elements, hence the index is $3$.
+
+\section*{8. Lagrange's Theorem}
+\textcolor{blue}{\textbf{Theorem.}} If $G$ is finite and $H\leq G$, then $|G|=[G:H]\cdot|H|$.
+\textcolor{blue}{\textbf{Proof sketch.}} Distinct left cosets of $H$ partition $G$ and each coset has $|H|$ elements, so the order of $G$ is a multiple of the order of $H$.
+
+\subsection*{Corollaries}
 \begin{itemize}
-  \item Left coset: $gH=\{g\star h: h\in H\}$.
-  \item Right coset: $Hg=\{h\star g: h\in H\}$.
-\end{itemize}
-Cosets are the same size as $H$, either equal or disjoint, and they partition $G$. The \textbf{index} $[G:H]$ counts the left cosets.
-\end{definitionbox}
-
-\subsection*{Coset Examples}
-\begin{examplebox}{1. $\mathbb{Z}_6$ with $H=\{0,3\}$}
-Cosets: $\{0,3\}$, $\{1,4\}$, $\{2,5\}$. Each has two elements, so $[\mathbb{Z}_6:H]=3$.
-\end{examplebox}
-
-\begin{examplebox}{2. $S_3$ with $H=\langle(12)\rangle$}
-Cosets: $H$, $(13)H=\{(13),(132)\}$, $(23)H=\{(23),(123)\}$. Again $[S_3:H]=3$.
-\end{examplebox}
-
-\section*{Lagrange's Theorem}
-\begin{definitionbox}{Statement}
-If $G$ is finite and $H\leq G$, then $|G|=[G:H]\cdot|H|$. Hence $|H|$ divides $|G|$.
-\end{definitionbox}
-
-\begin{examplebox}{Why It Works}
-$G$ breaks into disjoint cosets $g_1H,\dots,g_kH$. Each has $|H|$ elements, so $|G|=k\cdot|H|$ with $k=[G:H]$.
-\end{examplebox}
-
-\subsection*{Key Corollaries}
-\begin{itemize}
-  \item \textbf{Order of an element divides $|G|$.} If $a\in G$, then $|\langle a\rangle|$ divides $|G|$, so $a^{|G|}=e$ in finite groups.
-  \item \textbf{Groups of prime order are cyclic.}
-  \item \textbf{Fermat's little theorem:} in $U_p=\{1,2,\dots,p-1\}$ under multiplication mod $p$, $a^{p-1}\equiv1\pmod p$.
+  \item The order of an element divides the order of the group; consequently $a^{|G|}=e$ for all $a$ in a finite group.
+  \item A group of prime order is cyclic.
+  \item Fermat's little theorem: for prime $p$ and $a$ not divisible by $p$, $a^{p-1}\equiv1\pmod p$.
 \end{itemize}
 
-\subsection*{Worked Applications}
-\begin{examplebox}{1. Subgroup Sizes of $S_3$}
-Divisors of $6$ are $1,2,3,6$; no subgroup of size $4$ or $5$ exists.
-\end{examplebox}
+\subsection*{Applications}
+\paragraph{Subgroup sizes of $S_3$.}
+Possible sizes are the divisors of $6$, namely $1,2,3,$ and $6$.
 
-\begin{examplebox}{2. Orders in $\mathbb{Z}_{12}$ under $+$}
-Orders divide $12$: $\operatorname{ord}(1)=12$, $\operatorname{ord}(2)=6$, $\operatorname{ord}(3)=4$, $\operatorname{ord}(4)=3$, $\operatorname{ord}(6)=2$, $\operatorname{ord}(0)=1$.
-\end{examplebox}
+\paragraph{Orders in $\mathbb{Z}_{12}$.}
+The element $4$ has order $3$ because $4+4+4=12\equiv0$, and similarly $2$ has order $6$ and $6$ has order $2$.
 
-\begin{examplebox}{3. No element of order $6$ in $S_3$}
-Allowed by Lagrange, but actual element orders are only $1,2,$ or $3$.
-\end{examplebox}
+\paragraph{No element of order $6$ in $S_3$.}
+Although $6$ divides $|S_3|$, the elements of $S_3$ have orders $1,2,$ or $3$ only.
 
-\begin{examplebox}{4. Index in $\mathbb{Z}_{12}$}
-For $H=\langle4\rangle=\{0,4,8\}$, $|H|=3$ and $[\mathbb{Z}_{12}:H]=4$. Cosets are $\{0,4,8\}$, $\{1,5,9\}$, $\{2,6,10\}$, $\{3,7,11\}$.
-\end{examplebox}
+\paragraph{Index in $\mathbb{Z}_{12}$.}
+With $H=\langle4\rangle=\{0,4,8\}$ we have four distinct cosets
+\[
+\{0,4,8\},\quad \{1,5,9\},\quad \{2,6,10\},\quad \{3,7,11\},
+\]
+so $[\mathbb{Z}_{12}:H]=4$.
 
-\section*{Common Pitfalls}
-\begin{warnbox}{Be Careful!}
+\section*{9. Common Pitfalls}
 \begin{itemize}
-  \item Closure is more than being nonempty.
-  \item Many groups are not abelian.
-  \item ``Divides" does not guarantee existence.
-  \item Every subgroup must contain the identity.
+  \item Closure means results stay in the set; it is not automatic from non-emptiness.
+  \item Many groups are not abelian—never assume commutativity.
+  \item Lagrange's theorem gives a necessary divisibility condition but does not guarantee the existence of elements of a given order.
+  \item Every subgroup must contain the identity element of the ambient group.
 \end{itemize}
-\end{warnbox}
 
-\section*{Mini Checklists}
-\begin{examplebox}{Testing a Subgroup}
+\section*{10. Practice Problems}
 \begin{itemize}
-  \item Nonempty?
-  \item For all $a,b\in H$, is $ab^{-1}$ in $H$?
-\end{itemize}
-\end{examplebox}
-
-\begin{examplebox}{Computing Cosets}
-\begin{itemize}
-  \item Pick a representative $g$.
-  \item Form $gH=\{gh:h\in H\}$.
-  \item Repeat with elements not yet used.
-\end{itemize}
-\end{examplebox}
-
-\section*{Quick Practice}
-\begin{itemize}
-  \item Is $\{0,3,6,9\}$ a subgroup of $\mathbb{Z}_{12}$ under $+$?
+  \item Is $\{0,3,6,9\}$ a subgroup of $\mathbb{Z}_{12}$ under addition?
   \item List all cosets of $H=\{0,2,4\}$ in $\mathbb{Z}_6$.
   \item In $S_3$, why is $\{(12),(13)\}$ not a subgroup?
-  \item Find $\operatorname{ord}(2)$ in $\mathbb{Z}_8$ and list $\langle2\rangle$.
-  \item Show every finite subgroup of $(\mathbb{R}^*,\times)$ is cyclic.
+  \item Find the order of $2$ in $\mathbb{Z}_8$ and describe $\langle2\rangle$.
+  \item Prove that any finite subgroup of $(\mathbb{R}^*,\times)$ is cyclic.
 \end{itemize}
 
 \section*{Summary}
-Groups require \textcolor{blue}{closure}, \textcolor{blue}{associativity}, an \textcolor{blue}{identity}, and \textcolor{blue}{inverses}. Subgroups pass the test $ab^{-1}\in H$. Cosets split the group into equal pieces, leading to \textcolor{purple}{Lagrange's Theorem}: $|G|=[G:H]\cdot|H|$. These tools classify small groups, compute orders, and prove number theory facts.
+Groups combine elements through a binary operation obeying closure, associativity, an identity, and inverses.
+Subgroups satisfy the same rules and can be tested with the single condition $ab^{-1}\in H$.
+Cosets partition a group into equal-sized pieces, leading to Lagrange's theorem that the order of a subgroup divides the order of the whole group.
+These tools let us compute element orders, classify small groups, and apply group theory to number theory.
 
 \end{document}

--- a/introduction_to_group_theory.tex
+++ b/introduction_to_group_theory.tex
@@ -1,196 +1,618 @@
 \documentclass[12pt]{article}
 \usepackage{amsmath,amssymb,amsfonts}
-\usepackage{xcolor}
+\usepackage[svgnames]{xcolor}
 \usepackage{hyperref}
+\usepackage{tcolorbox}
+\usepackage{graphicx}
+\usepackage{enumerate}
+\usepackage{multicol}
+\tcbuselibrary{skins,breakable}
 
-\title{From Zero to Lagrange\\\small Lecture Notes on Group Theory}
-\author{}
-\date{}
+% --- Enhanced Color Palette ---
+\definecolor{deepmintgreen}{rgb}{0.0,0.4,0.3}
+\definecolor{richpurple}{rgb}{0.4,0.0,0.5}
+\definecolor{warmgold}{rgb}{0.8,0.6,0.0}
+\definecolor{lightmint}{rgb}{0.9,0.98,0.95}
+\definecolor{lightpurple}{rgb}{0.98,0.95,0.98}
+\definecolor{lightgold}{rgb}{0.99,0.98,0.9}
+\definecolor{softgray}{rgb}{0.96,0.97,0.98}
+
+% --- Color Assignments ---
+\definecolor{TitleColor}{named}{deepmintgreen}
+\definecolor{SectionColor}{named}{richpurple}\definecolor{HeaderColor}{named}{richpurple}
+\definecolor{KeyTermColor}{named}{deepmintgreen}
+\definecolor{AbelianColor}{named}{warmgold}
+
+\hypersetup{
+    colorlinks=true,
+    linkcolor=richpurple,
+    urlcolor=richpurple
+}
+
+% --- Simplified Box Styles (Only 3 types) ---
+\newtcolorbox{definitionbox}{
+    colback=lightgold, 
+    colframe=warmgold, 
+    coltitle=warmgold, 
+    title=Definition, 
+    fonttitle=\bfseries, 
+    breakable,
+    arc=3pt,
+    boxrule=1.5pt
+}
+
+\newtcolorbox{theorembox}{
+    colback=lightmint, 
+    colframe=deepmintgreen, 
+    coltitle=deepmintgreen, 
+    title=Theorem, 
+    fonttitle=\bfseries, 
+    breakable,
+    arc=3pt,
+    boxrule=1.5pt
+}
+
+\newtcolorbox{examplebox}{
+    colback=lightpurple, 
+    colframe=richpurple, 
+    coltitle=richpurple, 
+    title=Example, 
+    fonttitle=\bfseries, 
+    breakable,
+    arc=3pt,
+    boxrule=1.5pt
+}
+
+\title{\textcolor{TitleColor}{\LARGE From Zero to Lagrange: A Journey Through Group Theory}\\\large\textcolor{deepmintgreen}{Interactive Lecture Notes}}
+\author{Instructor: Jayakumar Ravindran \\ Department of Mathematics \\ The Institute of Mathematical Sciences \\ Chennai, Tamil Nadu, India}
+\date{Academic Year 2024-25 \\ \today}
 
 \begin{document}
+\pagecolor{softgray}
+
 \maketitle
 
-\section*{1. Getting Started}
-To study groups we need a set $G$ together with a way to combine any two of its elements.
-Throughout these notes the operation will be denoted by $\star$.
-Before calling $(G,\star)$ a \textcolor{blue}{group} we must check four requirements: \textcolor{blue}{closure}, \textcolor{blue}{associativity}, the presence of an \textcolor{blue}{identity} element, and the existence of \textcolor{blue}{inverses}.
+\begin{center}
+\large\textit{\textcolor{richpurple}{``Welcome to our mathematical adventure! Today we're going to explore one of the most beautiful and fundamental structures in mathematics: groups. Don't worry if this is your first encounter with abstract algebra – we'll build everything from the ground up, just like constructing a house brick by brick.''}}
+\end{center}
 
-\section*{2. Definition of a Group}
-\textcolor{blue}{\textbf{Definition.}} A pair $(G,\star)$ is a group if for all $a,b,c\in G$:
+\tableofcontents
+\newpage
+
+\section{\textcolor{SectionColor}{Introduction: What Are We Doing Here?}}
+
+Hello everyone! Before we dive into the formal definitions, let me ask you a question: What do the rotations of a triangle, the symmetries of a snowflake, and the arithmetic of clock faces have in common? 
+
+The answer might surprise you – they all follow the same mathematical pattern, which we call a \textbf{\textcolor{KeyTermColor}{group}}. Today, we're going to uncover this pattern and see how it appears everywhere in mathematics.
+
+Think about this: When you're late for class and you check your watch, you might see it's 11 AM and realize your class started at 9 AM. You think, ``I'm 2 hours late.'' But wait – what if it's 11 PM and your class was at 9 AM? Now you're not 2 hours late; you're 14 hours late, or as we might say on a 12-hour clock, 2 hours late for tomorrow's class. This wrapping around behavior is our first glimpse into group theory!
+
+\section{\textcolor{SectionColor}{Getting Our Hands Dirty: What Makes a Group?}}
+
+Let's start with something concrete. Imagine you have a set of elements – could be numbers, could be geometric transformations, could be anything really. We'll call this set $G$. Now, we need a way to combine any two elements from this set. We'll use the symbol $\star$ for this combination rule.
+
+But here's the key insight: we can't just randomly combine elements and call it a day. For $(G,\star)$ to deserve the prestigious title of ``group,'' it must satisfy four very specific requirements. Think of these as the four pillars that hold up our mathematical structure.
+
+Imagine you're a quality control inspector at a mathematical factory. Every time someone claims they've built a group, you need to check these four things. Miss even one, and sorry – not a group!
+
+Let me walk you through each requirement:
+
+\begin{itemize}
+\item \textbf{\textcolor{KeyTermColor}{Closure}}: When you combine any two elements from $G$ using $\star$, you must get something that's still in $G$. No sneaking out of the set!
+\item \textbf{\textcolor{KeyTermColor}{Associativity}}: The order of operations shouldn't matter for grouping. That is, $(a\star b)\star c = a\star(b\star c)$.
+\item \textbf{\textcolor{KeyTermColor}{Identity Element}}: There must be some special element $e$ in $G$ that, when combined with any other element, leaves it unchanged.
+\item \textbf{\textcolor{KeyTermColor}{Inverse Elements}}: Every element must have a partner that, when combined with it, gives you back the identity.
+\end{itemize}
+
+\section{\textcolor{SectionColor}{The Formal Definition}}
+
+Now that we've talked through the intuition, let's write this down mathematically. Don't worry – it's just a formal way of saying what we just discussed.
+
+\begin{definitionbox}
+A pair $(G,\star)$ is called a \textbf{group} if $G$ is a non-empty set and $\star$ is a binary operation on $G$ such that for all $a,b,c\in G$:
+
 \begin{enumerate}
   \item \textbf{Closure:} $a\star b$ lies in $G$.
   \item \textbf{Associativity:} $(a\star b)\star c = a\star(b\star c)$.
-  \item \textbf{Identity:} there exists $e\in G$ with $e\star a=a\star e=a$ for every $a$.
-  \item \textbf{Inverses:} each $a$ has $a^{-1}$ in $G$ such that $a\star a^{-1}=a^{-1}\star a=e$.
+  \item \textbf{Identity:} There exists an element $e\in G$ such that $e\star a=a\star e=a$ for every $a\in G$.
+  \item \textbf{Inverses:} For each element $a\in G$, there exists an element $a^{-1}\in G$ such that $a\star a^{-1}=a^{-1}\star a=e$.
 \end{enumerate}
-If $a\star b=b\star a$ for all $a,b$, the group is called \textcolor{purple}{abelian}.
 
-\section*{3. Verifying a Group}
-When presenting a new structure, begin by describing the set and the operation.
-Check closure by combining generic elements, appeal to known associativity when possible, identify the element that leaves others unchanged, and finally produce an inverse for a typical element.
+If additionally $a\star b=b\star a$ for all $a,b\in G$, we call the group \textcolor{AbelianColor}{\textbf{abelian}} (named after Niels Henrik Abel).
+\end{definitionbox}
 
-\section*{4. Examples and Non-examples}
-\subsection*{Example: $(\mathbb{Z},+)$}
-Given integers $m$ and $n$, their sum $m+n$ is an integer, so the set is closed under addition.
-Addition of integers is associative, $0$ acts as the identity, and $m+(-m)=0$ shows that $-m$ is the inverse of $m$.
-The operation is commutative, hence $\mathbb{Z}$ is abelian.
+Important Note: Don't assume a group is abelian unless you can prove it! Many groups are NOT commutative. In fact, most interesting groups are non-abelian.
 
-\subsection*{Example: $(\mathbb{Z}_n,+ \text{ mod } n)$}
-The set $\mathbb{Z}_n=\{0,1,\ldots,n-1\}$ is closed under addition modulo $n$.
-For instance in $\mathbb{Z}_6$,
+\section{\textcolor{SectionColor}{How to Verify You Have a Group}}
+
+When someone presents you with a potential group, here's your game plan:
+
+\begin{enumerate}
+\item \textbf{Describe the set and operation clearly.} What are we working with?
+\item \textbf{Check closure.} Pick generic elements and show their combination stays in the set.
+\item \textbf{Verify associativity.} This is often the trickiest part, but sometimes you can appeal to known results.
+\item \textbf{Find the identity.} Look for the element that leaves everything alone.
+\item \textbf{Show inverses exist.} For each element, find its partner that cancels it out.
+\end{enumerate}
+
+\section{\textcolor{SectionColor}{Let's See Some Groups in Action!}}
+
+Now for the fun part – let's look at some actual groups! I'll show you several examples, and trust me, you'll start seeing groups everywhere once you know what to look for.
+
+\subsection{\textcolor{HeaderColor}{Example 1: The Integers Under Addition $(\mathbb{Z},+)$}}
+
+\begin{examplebox}
+Let's check if the integers with regular addition form a group.
+
+\textbf{The Set:} $\mathbb{Z} = \{\ldots, -2, -1, 0, 1, 2, \ldots\}$ \\
+\textbf{The Operation:} Regular addition $+$
+
+\textbf{Closure:} If $m$ and $n$ are integers, is $m+n$ an integer? Absolutely! We learned this in elementary school.
+
+\textbf{Associativity:} Does $(m+n)+p = m+(n+p)$? Yes, addition is associative – another elementary school fact that turns out to be profound!
+
+\textbf{Identity:} What integer leaves all others unchanged when added? That's $0$, because $0+m = m+0 = m$ for any integer $m$.
+
+\textbf{Inverses:} Given any integer $m$, what do we add to get $0$? We add $-m$, because $m+(-m) = (-m)+m = 0$.
+
+Also notice: $m+n = n+m$ for all integers, so this group is abelian.
+\end{examplebox}
+
+\subsection{\textcolor{HeaderColor}{Example 2: Clock Arithmetic $(\mathbb{Z}_n, +_n)$}}
+
+Remember our clock example from the introduction? Let's make it formal.
+
+\begin{examplebox}
+Consider $\mathbb{Z}_6 = \{0, 1, 2, 3, 4, 5\}$ with addition modulo $6$.
+
+Think of this as clock arithmetic on a 6-hour clock. When we add:
+\begin{align}
+2 + 3 &= 5 \\
+4 + 5 &= 9 \equiv 3 \pmod{6} \\
+3 + 4 &= 7 \equiv 1 \pmod{6}
+\end{align}
+
+Let's verify this is a group:
+
+\textbf{Closure:} When we add any two elements from $\{0,1,2,3,4,5\}$, we might get a number bigger than 5, but after taking modulo 6, we're back in our set.
+
+\textbf{Identity:} The element $0$ works: $0 + k \equiv k \pmod{6}$ for any $k$.
+
+\textbf{Inverses:} 
+\begin{align}
+0^{-1} &= 0 \quad \text{(since } 0+0 = 0\text{)} \\
+1^{-1} &= 5 \quad \text{(since } 1+5 = 6 \equiv 0 \pmod{6}\text{)} \\
+2^{-1} &= 4 \quad \text{(since } 2+4 = 6 \equiv 0 \pmod{6}\text{)} \\
+3^{-1} &= 3 \quad \text{(since } 3+3 = 6 \equiv 0 \pmod{6}\text{)}
+\end{align}
+\end{examplebox}
+
+\subsection{\textcolor{HeaderColor}{Example 3: Non-Zero Rationals Under Multiplication $(\mathbb{Q}^*, \times)$}}
+
+\begin{examplebox}
+Here's where we see why we need to be careful about our sets.
+
+\textbf{The Set:} $\mathbb{Q}^* = \mathbb{Q} \setminus \{0\}$ (all rational numbers except zero) \\
+\textbf{The Operation:} Regular multiplication
+
+Why exclude zero? Because $0$ has no multiplicative inverse!
+
+\textbf{Closure:} The product of two non-zero rationals is a non-zero rational.
+
+\textbf{Identity:} The number $1$ satisfies $1 \cdot r = r \cdot 1 = r$ for all rationals $r$.
+
+\textbf{Inverses:} For any rational $\frac{a}{b}$ (where $a,b \neq 0$), the inverse is $\frac{b}{a}$ because $\frac{a}{b} \cdot \frac{b}{a} = 1$.
+\end{examplebox}
+
+\subsection{\textcolor{HeaderColor}{Example 4: Matrix Groups $GL_2(\mathbb{R})$}}
+
+Now we're getting into more sophisticated territory!
+
+\begin{examplebox}
+$GL_2(\mathbb{R})$ consists of all invertible $2 \times 2$ real matrices under matrix multiplication.
+
+\textbf{Why only invertible matrices?} Because we need every element to have an inverse!
+
+Let's see why this group is non-abelian:
 \[
-4+5=9\equiv 3 \pmod 6.
+A = \begin{bmatrix} 1 & 1 \\ 0 & 1 \end{bmatrix}, \quad B = \begin{bmatrix} 1 & 0 \\ 1 & 1 \end{bmatrix}
 \]
-The class $0$ serves as identity and the inverse of $k$ is $n-k$.
 
-\subsection*{Example: $(\mathbb{Q}^*,\times)$ and $(\mathbb{R}^*,\times)$}
-Multiplication of nonzero rationals or reals is associative and closed.
-The number $1$ is the identity and the inverse of $\frac{a}{b}$ is $\frac{b}{a}$.
-Both groups are abelian.
-
-\subsection*{Example: $\mathrm{GL}_2(\mathbb{R})$}
-This group consists of all invertible $2\times2$ real matrices under multiplication.
-Closure follows because the product of invertible matrices is invertible.
-For
+Computing the products:
 \[
-A=\begin{bmatrix}1&1\\0&1\end{bmatrix},\quad
-B=\begin{bmatrix}1&0\\1&1\end{bmatrix},
+AB = \begin{bmatrix} 1 & 1 \\ 0 & 1 \end{bmatrix} \begin{bmatrix} 1 & 0 \\ 1 & 1 \end{bmatrix} = \begin{bmatrix} 2 & 1 \\ 1 & 1 \end{bmatrix}
 \]
-we compute
+
 \[
-AB=\begin{bmatrix}2&1\\1&1\end{bmatrix},\qquad
-BA=\begin{bmatrix}1&1\\1&2\end{bmatrix},
+BA = \begin{bmatrix} 1 & 0 \\ 1 & 1 \end{bmatrix} \begin{bmatrix} 1 & 1 \\ 0 & 1 \end{bmatrix} = \begin{bmatrix} 1 & 1 \\ 1 & 2 \end{bmatrix}
 \]
-so $AB\neq BA$ and the group is not abelian.
 
-\subsection*{Example: Symmetric Group $S_3$}
-$S_3$ contains the six permutations of $\{1,2,3\}$.
-Composition of permutations is associative and the identity map fixes each number.
-The permutation $(12)(23)$ sends $1\mapsto2\mapsto3$, $2\mapsto3\mapsto1$, and $3\mapsto1\mapsto2$, giving $(123)$.
-Because $(12)(23)\neq(23)(12)$ the group is non-abelian.
+Since $AB \neq BA$, this group is non-abelian!
+\end{examplebox}
 
-\subsection*{Example: Dihedral Group $D_4$}
-$D_4$ records symmetries of a square: four rotations and four reflections.
-Rotation by $90^{\circ}$ composed four times returns the square to its original position, while reflections reverse orientation; the operation is composition of these symmetries.
-The group fails to be abelian because, for example, reflecting then rotating is different from rotating then reflecting.
+\subsection{\textcolor{HeaderColor}{Example 5: The Symmetric Group $S_3$}}
 
-\subsection*{Example: Klein Four Group $V_4$}
-The set $\{e,a,b,c\}$ with relations $a^2=b^2=c^2=e$ and $ab=c$, $bc=a$, $ca=b$ forms a group.
-Each element is its own inverse and the operation is commutative, but no single element generates the entire group.
+This is where group theory gets really exciting! We're going to study the symmetries of mathematical objects.
 
-\subsection*{Non-examples}
-The natural numbers under addition lack inverses, the integers under multiplication lack inverses for most elements, and real numbers with subtraction violate associativity.
+\begin{examplebox}
+$S_3$ is the group of all permutations (rearrangements) of three objects. Let's say we're permuting the set $\{1, 2, 3\}$.
 
-\section*{5. Fundamental Notions}
-The \textcolor{blue}{order} of an element $a$ is the smallest positive integer $k$ with $a^k=e$ (or $k\cdot a=0$ in additive notation).
-A group is \textcolor{blue}{cyclic} if one element generates all others: $G=\langle g\rangle=\{\ldots,g^{-1},e,g,g^{2},\ldots\}$.
-The \textcolor{blue}{order of the group} is the number of elements it contains.
+The elements of $S_3$ are:
+\begin{align}
+e &= \text{identity (do nothing)} \\
+(12) &= \text{swap 1 and 2} \\
+(13) &= \text{swap 1 and 3} \\
+(23) &= \text{swap 2 and 3} \\
+(123) &= \text{cycle: } 1 \to 2 \to 3 \to 1 \\
+(132) &= \text{cycle: } 1 \to 3 \to 2 \to 1
+\end{align}
 
-\section*{6. Subgroups}
-\textcolor{blue}{\textbf{Definition.}} A nonempty subset $H$ of $G$ is a subgroup, written $H\leq G$, if for all $a,b\in H$ the element $ab^{-1}$ also lies in $H$.
-In additive groups we test closure under subtraction.
+The operation is composition. For example:
+$(12)(23)$ means ``first swap 2 and 3, then swap 1 and 2.''
 
-\subsection*{Useful Facts}
+Let's trace this: Start with $(1,2,3)$
+\begin{align}
+(1,2,3) \xrightarrow{(23)} (1,3,2) \xrightarrow{(12)} (3,1,2)
+\end{align}
+
+So $(12)(23) = (123)$. But $(23)(12) = (132) \neq (123)$!
+
+This shows $S_3$ is non-abelian.
+\end{examplebox}
+
+\subsection{\textcolor{HeaderColor}{Example 6: Dihedral Group $D_4$ - Symmetries of a Square}}
+
+\begin{examplebox}
+Imagine a square sitting on your desk. What are all the ways you can move it so it looks exactly the same as before?
+
+\textbf{Rotations:}
 \begin{itemize}
-  \item The identity of $G$ is always in $H$.
-  \item If $a\in H$ then $a^{-1}\in H$.
-  \item Intersections of subgroups are subgroups.
-  \item The subgroup generated by a set $S$ is the smallest subgroup containing $S$ and is denoted $\langle S\rangle$.
+\item $r^0 = e$: do nothing (identity)
+\item $r^1 = r$: rotate $90°$ counterclockwise  
+\item $r^2$: rotate $180°$
+\item $r^3$: rotate $270°$ 
 \end{itemize}
 
-\subsection*{Examples}
-\paragraph{1. $k\mathbb{Z}$ inside $\mathbb{Z}$.}
-For an integer $k$, the set $k\mathbb{Z}=\{\ldots,-2k,-k,0,k,2k,\ldots\}$ is closed under subtraction, hence forms a subgroup.
-
-\paragraph{2. Subgroups of $\mathbb{Z}_6$.}
-Every subgroup is generated by a divisor of $6$:
-\[
-\{0\},\quad \{0,3\},\quad \{0,2,4\},\quad \mathbb{Z}_6.
-\]
-The subset $\{0,2\}$ is not a subgroup since $2+2=4\notin\{0,2\}$.
-
-\paragraph{3. Subgroups of $S_3$.}
-They have sizes $1,2,3,$ or $6$.
-Besides the trivial subgroup and $S_3$ itself, there are three subgroups generated by transpositions and a three-element subgroup $\{e,(123),(132)\}$.
-
-\paragraph{4. The center $Z(G)$.}
-$Z(G)=\{g\in G: gx=xg \text{ for all } x\in G\}$ is a subgroup because products and inverses of commuting elements also commute.
-
-\paragraph{5. Rotations in $D_4$.}
-The set $\{e,r,r^2,r^3\}$ of rotations is a subgroup of order $4$.
-
-\paragraph{6. Upper triangular matrices.}
-The invertible upper triangular matrices form a subgroup of $\mathrm{GL}_2(\mathbb{R})$ since the product and inverse of such matrices remain upper triangular.
-
-\section*{7. Cosets and Index}
-Given $H\leq G$ and $g\in G$, the \textcolor{blue}{left coset} $gH$ is $\{gh:h\in H\}$ and the \textcolor{blue}{right coset} $Hg$ is $\{hg:h\in H\}$.
-All cosets have the same size as $H$; two cosets are either identical or disjoint, and the left cosets partition $G$.
-The number of distinct left cosets is called the \textcolor{blue}{index} and is written $[G:H]$.
-
-\subsection*{Examples}
-\paragraph{$\mathbb{Z}_6$ with $H=\{0,3\}$.}
-The cosets are
-\[
-0+H=\{0,3\},\quad 1+H=\{1,4\},\quad 2+H=\{2,5\},
-\]
-so $[\mathbb{Z}_6:H]=3$.
-
-\paragraph{$S_3$ with $H=\langle(12)\rangle$.}
-We obtain three cosets:
-\[
-H=\{e,(12)\},\quad (13)H=\{(13),(132)\},\quad (23)H=\{(23),(123)\}.
-\]
-Each coset has two elements, hence the index is $3$.
-
-\section*{8. Lagrange's Theorem}
-\textcolor{blue}{\textbf{Theorem.}} If $G$ is finite and $H\leq G$, then $|G|=[G:H]\cdot|H|$.
-\textcolor{blue}{\textbf{Proof sketch.}} Distinct left cosets of $H$ partition $G$ and each coset has $|H|$ elements, so the order of $G$ is a multiple of the order of $H$.
-
-\subsection*{Corollaries}
+\textbf{Reflections:}
 \begin{itemize}
-  \item The order of an element divides the order of the group; consequently $a^{|G|}=e$ for all $a$ in a finite group.
-  \item A group of prime order is cyclic.
-  \item Fermat's little theorem: for prime $p$ and $a$ not divisible by $p$, $a^{p-1}\equiv1\pmod p$.
+\item $f_1$: flip across vertical axis
+\item $f_2$: flip across horizontal axis  
+\item $f_3$: flip across one diagonal
+\item $f_4$: flip across other diagonal
 \end{itemize}
 
-\subsection*{Applications}
-\paragraph{Subgroup sizes of $S_3$.}
-Possible sizes are the divisors of $6$, namely $1,2,3,$ and $6$.
+The group $D_4$ has 8 elements total. It's non-abelian because rotating then reflecting gives a different result than reflecting then rotating.
+\end{examplebox}
 
-\paragraph{Orders in $\mathbb{Z}_{12}$.}
-The element $4$ has order $3$ because $4+4+4=12\equiv0$, and similarly $2$ has order $6$ and $6$ has order $2$.
+\subsection{\textcolor{HeaderColor}{Example 7: Klein Four-Group $V_4$}}
 
-\paragraph{No element of order $6$ in $S_3$.}
-Although $6$ divides $|S_3|$, the elements of $S_3$ have orders $1,2,$ or $3$ only.
+\begin{examplebox}
+Here's a cute little group that might surprise you:
 
-\paragraph{Index in $\mathbb{Z}_{12}$.}
-With $H=\langle4\rangle=\{0,4,8\}$ we have four distinct cosets
-\[
-\{0,4,8\},\quad \{1,5,9\},\quad \{2,6,10\},\quad \{3,7,11\},
-\]
-so $[\mathbb{Z}_{12}:H]=4$.
-
-\section*{9. Common Pitfalls}
+$V_4 = \{e, a, b, c\}$ with the operation defined by:
 \begin{itemize}
-  \item Closure means results stay in the set; it is not automatic from non-emptiness.
-  \item Many groups are not abelian—never assume commutativity.
-  \item Lagrange's theorem gives a necessary divisibility condition but does not guarantee the existence of elements of a given order.
-  \item Every subgroup must contain the identity element of the ambient group.
+\item Every element is its own inverse: $a^2 = b^2 = c^2 = e$
+\item $ab = c$, $bc = a$, $ca = b$
 \end{itemize}
 
-\section*{10. Practice Problems}
+This group is abelian (you can check!), but unlike $\mathbb{Z}_4$, no single element generates the whole group. It's like having three different ``flips'' that interact in a very specific way.
+\end{examplebox}
+
+\section{\textcolor{SectionColor}{What's NOT a Group? Learning from Failures}}
+
+Sometimes the best way to understand something is to see what it's not!
+
+Non-example 1: Natural Numbers Under Addition \\
+$(\mathbb{N}, +)$ fails because there are no inverses. What's the inverse of 5 under addition? It should be $-5$, but $-5 \notin \mathbb{N}$.
+
+Non-example 2: Integers Under Subtraction \\
+$(\mathbb{Z}, -)$ fails associativity: $(5-3)-2 = 0$ but $5-(3-2) = 4$.
+
+Non-example 3: All $2 \times 2$ Matrices Under Multiplication \\
+This fails because not every matrix has an inverse. For instance, $\begin{bmatrix} 1 & 1 \\ 1 & 1 \end{bmatrix}$ is not invertible.
+
+\section{\textcolor{SectionColor}{Key Concepts Every Group Theorist Should Know}}
+
+\subsection{\textcolor{HeaderColor}{Order of Elements}}
+
+\begin{definitionbox}
+The \textbf{order} of an element $a$ in a group is the smallest positive integer $n$ such that $a^n = e$ (the identity). If no such $n$ exists, we say $a$ has infinite order.
+
+In additive notation, we look for the smallest positive $n$ such that $na = 0$.
+\end{definitionbox}
+
+Let's look at some examples in $\mathbb{Z}_{12}$:
 \begin{itemize}
-  \item Is $\{0,3,6,9\}$ a subgroup of $\mathbb{Z}_{12}$ under addition?
-  \item List all cosets of $H=\{0,2,4\}$ in $\mathbb{Z}_6$.
-  \item In $S_3$, why is $\{(12),(13)\}$ not a subgroup?
-  \item Find the order of $2$ in $\mathbb{Z}_8$ and describe $\langle2\rangle$.
-  \item Prove that any finite subgroup of $(\mathbb{R}^*,\times)$ is cyclic.
+\item Order of $3$: We need $3k \equiv 0 \pmod{12}$. The smallest positive $k$ is $4$, so $\text{ord}(3) = 4$.
+\item Order of $5$: We need $5k \equiv 0 \pmod{12}$. The smallest positive $k$ is $12$, so $\text{ord}(5) = 12$.
+\item Order of $6$: We need $6k \equiv 0 \pmod{12}$. Since $6 \cdot 2 = 12 \equiv 0$, we have $\text{ord}(6) = 2$.
 \end{itemize}
 
-\section*{Summary}
-Groups combine elements through a binary operation obeying closure, associativity, an identity, and inverses.
-Subgroups satisfy the same rules and can be tested with the single condition $ab^{-1}\in H$.
-Cosets partition a group into equal-sized pieces, leading to Lagrange's theorem that the order of a subgroup divides the order of the whole group.
-These tools let us compute element orders, classify small groups, and apply group theory to number theory.
+\subsection{\textcolor{HeaderColor}{Cyclic Groups}}
+
+\begin{definitionbox}
+A group $G$ is \textbf{cyclic} if there exists an element $g \in G$ such that every element of $G$ can be written as $g^k$ for some integer $k$. We write $G = \langle g \rangle$ and call $g$ a \textbf{generator} of $G$.
+\end{definitionbox}
+
+Think of cyclic groups as the ``spinning wheel'' groups. You have one element, and by repeatedly applying the group operation, you generate everything else. It's like having a dial that you can turn – each position corresponds to a group element.
+
+For example, $\mathbb{Z}_6 = \{0, 1, 2, 3, 4, 5\}$ is cyclic with generator $1$:
+\begin{align}
+1^0 &= 0 & 1^1 &= 1 & 1^2 &= 2 \\
+1^3 &= 3 & 1^4 &= 4 & 1^5 &= 5 \\
+1^6 &= 0 & \text{(back to start)}
+\end{align}
+
+Notice that $5$ is also a generator because $\gcd(5,6) = 1$.
+
+\subsection{\textcolor{HeaderColor}{Group Order}}
+
+The \textbf{order} of a group $G$, denoted $|G|$, is simply the number of elements in $G$. If $G$ has infinitely many elements, we write $|G| = \infty$.
+
+\section{\textcolor{SectionColor}{Subgroups: Groups Within Groups}}
+
+Here's where things get really interesting! Sometimes, hiding inside a big group, there are smaller groups just waiting to be discovered.
+
+\begin{definitionbox}
+Let $(G, \star)$ be a group. A non-empty subset $H \subseteq G$ is called a \textbf{subgroup} of $G$ (written $H \leq G$) if $H$ is itself a group under the operation $\star$.
+
+\textbf{Subgroup Test:} A non-empty subset $H$ of $G$ is a subgroup if and only if for all $a, b \in H$, we have $ab^{-1} \in H$.
+\end{definitionbox}
+
+The subgroup test is incredibly efficient! Instead of checking four conditions, we only need to check one. It's like having a master key that opens all doors at once.
+
+Why does this work? If $a, b \in H$, then:
+\begin{itemize}
+\item Taking $a = b$ gives us $aa^{-1} = e \in H$ (identity exists)
+\item Taking $a = e$ gives us $eb^{-1} = b^{-1} \in H$ (inverses exist)  
+\item If $b^{-1} \in H$, then taking $a, b^{-1} \in H$ gives us $a(b^{-1})^{-1} = ab \in H$ (closure)
+\end{itemize}
+
+\subsection{\textcolor{HeaderColor}{Subgroup Examples That Will Blow Your Mind}}
+
+\begin{examplebox}
+\textbf{Example 1: $k\mathbb{Z}$ in $\mathbb{Z}$}
+
+For any integer $k$, the set $k\mathbb{Z} = \{..., -2k, -k, 0, k, 2k, ...\}$ is a subgroup of $\mathbb{Z}$.
+
+Let's verify: If $a, b \in k\mathbb{Z}$, then $a = km$ and $b = kn$ for some integers $m, n$.
+So $a - b = km - kn = k(m-n) \in k\mathbb{Z}$.
+\end{examplebox}
+
+\begin{examplebox}
+\textbf{Example 2: All Subgroups of $\mathbb{Z}_6$}
+
+The subgroups of $\mathbb{Z}_6$ are:
+\begin{itemize}
+\item $\{0\}$ - the trivial subgroup
+\item $\{0, 3\} = \langle 3 \rangle$ 
+\item $\{0, 2, 4\} = \langle 2 \rangle$
+\item $\{0, 1, 2, 3, 4, 5\} = \mathbb{Z}_6$ itself
+\end{itemize}
+
+Notice how the orders are $1, 2, 3, 6$ - all divisors of $6$! This is not a coincidence...
+\end{examplebox}
+
+\begin{examplebox}
+\textbf{Example 3: The Center of a Group}
+
+For any group $G$, define:
+\[Z(G) = \{g \in G : gx = xg \text{ for all } x \in G\}\]
+
+This is the set of all elements that commute with everything. It's always a subgroup!
+
+In $S_3$, only the identity commutes with everything, so $Z(S_3) = \{e\}$.
+In any abelian group $G$, we have $Z(G) = G$.
+\end{examplebox}
+
+\begin{examplebox}
+\textbf{Example 4: Rotational Subgroup of $D_4$}
+
+Inside the dihedral group $D_4$, the set of rotations $\{e, r, r^2, r^3\}$ forms a subgroup. It's cyclic with generator $r$.
+\end{examplebox}
+
+\section{\textcolor{SectionColor}{Cosets: Slicing Up Groups}}
+
+Now we come to one of the most powerful ideas in group theory. Imagine you have a pizza (your group $G$) and you want to slice it into equal pieces using a particular subgroup $H$ as your ``slice size.''
+
+\begin{definitionbox}
+Let $H$ be a subgroup of $G$ and let $g \in G$. The \textbf{left coset} of $H$ containing $g$ is:
+\[gH = \{gh : h \in H\}\]
+
+Similarly, the \textbf{right coset} of $H$ containing $g$ is:
+\[Hg = \{hg : h \in H\}\]
+
+The number of distinct left cosets is called the \textbf{index} of $H$ in $G$, denoted $[G:H]$.
+\end{definitionbox}
+
+Here's the beautiful thing about cosets: they partition the group! Every element belongs to exactly one coset, and all cosets have the same size as the subgroup $H$. It's like cutting a cake into perfectly equal slices.
+
+\subsection{\textcolor{HeaderColor}{Coset Examples}}
+
+\begin{examplebox}
+\textbf{Cosets in $\mathbb{Z}_6$ with $H = \{0, 3\}$}
+
+Let's find all left cosets:
+\begin{align}
+0 + H &= \{0, 3\} \\
+1 + H &= \{1, 4\} \\  
+2 + H &= \{2, 5\} \\
+3 + H &= \{3, 0\} = \{0, 3\} = 0 + H \\
+4 + H &= \{4, 1\} = \{1, 4\} = 1 + H \\
+5 + H &= \{5, 2\} = \{2, 5\} = 2 + H
+\end{align}
+
+So we have exactly three distinct cosets: $\{0,3\}$, $\{1,4\}$, $\{2,5\}$.
+Therefore, $[\mathbb{Z}_6 : H] = 3$.
+\end{examplebox}
+
+\begin{examplebox}
+\textbf{Cosets in $S_3$ with $H = \langle (12) \rangle = \{e, (12)\}$}
+
+The left cosets are:
+\begin{align}
+eH &= \{e, (12)\} \\
+(13)H &= \{(13), (13)(12)\} = \{(13), (132)\} \\
+(23)H &= \{(23), (23)(12)\} = \{(23), (123)\}
+\end{align}
+
+We get three cosets, each with 2 elements, so $[S_3 : H] = 3$.
+\end{examplebox}
+
+\section{\textcolor{SectionColor}{Lagrange's Theorem: The Crown Jewel}}
+
+We've been building up to this moment! Lagrange's theorem is one of the most important results in group theory, and now you'll see why all our work with cosets was worth it.
+
+\begin{theorembox}
+\textbf{Lagrange's Theorem:} If $G$ is a finite group and $H$ is a subgroup of $G$, then:
+\[|G| = [G:H] \cdot |H|\]
+
+In particular, the order of any subgroup divides the order of the group.
+\end{theorembox}
+
+\textbf{Proof Idea:} The left cosets of $H$ partition $G$ into disjoint sets, each having exactly $|H|$ elements. If there are $k$ distinct cosets, then $|G| = k \cdot |H|$. But $k = [G:H]$, so we're done! 
+
+\subsection{\textcolor{HeaderColor}{Mind-Blowing Consequences}}
+
+\begin{theorembox}
+\textbf{Corollary 1:} In a finite group $G$, the order of any element divides $|G|$.
+\end{theorembox}
+
+Why? If $a \in G$ has order $n$, then $\langle a \rangle = \{e, a, a^2, \ldots, a^{n-1}\}$ is a subgroup of order $n$. By Lagrange, $n$ divides $|G|$.
+
+\begin{theorembox}
+\textbf{Corollary 2:} If $|G| = p$ where $p$ is prime, then $G$ is cyclic.
+\end{theorembox}
+
+Why? Take any non-identity element $g$. Its order must divide $p$, so the order is either $1$ or $p$. Since $g \neq e$, the order can't be $1$, so it must be $p$. Therefore $G = \langle g \rangle$.
+
+\begin{theorembox}
+\textbf{Corollary 3 (Fermat's Little Theorem):} If $p$ is prime and $a$ is not divisible by $p$, then $a^{p-1} \equiv 1 \pmod{p}$.
+\end{theorembox}
+
+Connection to Groups: Consider the group $(\mathbb{Z}_p^*, \times)$ of non-zero elements modulo $p$. This group has order $p-1$. By Corollary 1, $a^{p-1} = 1$ in this group, which means $a^{p-1} \equiv 1 \pmod{p}$.
+
+\subsection{\textcolor{HeaderColor}{Applications Galore}}
+
+Since $|S_3| = 6 = 2 \times 3$, the possible subgroup orders are $1, 2, 3, 6$. We can find:
+\begin{itemize}
+\item Order 1: $\{e\}$
+\item Order 2: $\{e, (12)\}$, $\{e, (13)\}$, $\{e, (23)\}$  
+\item Order 3: $\{e, (123), (132)\}$
+\item Order 6: $S_3$ itself
+\end{itemize}
+
+For element orders in $\mathbb{Z}_{12}$, possible orders must divide $12$: so $1, 2, 3, 4, 6, 12$. Let's check some:
+\begin{itemize}
+\item Order of $4$: Since $4 \cdot 3 = 12 \equiv 0$, we have $\text{ord}(4) = 3$
+\item Order of $5$: We need the smallest $k$ with $5k \equiv 0 \pmod{12}$. Since $\gcd(5,12) = 1$, we get $\text{ord}(5) = 12$
+\item Order of $6$: Since $6 \cdot 2 = 12 \equiv 0$, we have $\text{ord}(6) = 2$
+\end{itemize}
+
+Important Limitation: Lagrange's theorem tells us what orders are possible, but not which ones actually occur! For example, there's no element of order $6$ in $S_3$ even though $6$ divides $|S_3| = 6$. The elements of $S_3$ have orders $1, 2$, or $3$ only.
+
+\section{\textcolor{SectionColor}{Common Mistakes and How to Avoid Them}}
+
+Let me share some mistakes I've seen students make over the years. Learn from others' errors!
+
+Mistake 1: Assuming Closure is Automatic \\
+Just because a set is non-empty doesn't mean it's closed under the operation! The set $\{1, -1, 2, -2\}$ under multiplication is NOT closed because $2 \times 2 = 4 \notin \{1, -1, 2, -2\}$.
+
+Mistake 2: Assuming All Groups are Abelian \\
+Many interesting groups are non-abelian! Never assume $ab = ba$ unless you can prove it. In $S_3$, we have $(12)(23) = (123)$ but $(23)(12) = (132) \neq (123)$.
+
+Mistake 3: Misunderstanding Lagrange's Theorem \\
+Lagrange tells us necessary conditions, not sufficient ones! Wrong thinking: ``Since $4$ divides $12$, there must be an element of order $4$ in any group of order $12$.'' Truth: There might be such an element, but Lagrange doesn't guarantee it.
+
+Mistake 4: Forgetting the Identity Must Come from the Ambient Group \\
+If $H$ is a subgroup of $G$, then the identity element of $H$ must be the same as the identity element of $G$. You can't have a ``subgroup'' of $(\mathbb{Z}, +)$ where the identity is $5$ instead of $0$.
+
+\section{\textcolor{SectionColor}{Advanced Examples and Special Groups}}
+
+Let's look at some more sophisticated examples that showcase the power and beauty of group theory.
+
+\subsection{\textcolor{HeaderColor}{The Quaternion Group $Q_8$}}
+
+\begin{examplebox}
+The quaternion group has 8 elements: $\{±1, ±i, ±j, ±k\}$ with relations:
+\begin{align}
+i^2 = j^2 = k^2 = ijk = -1
+\end{align}
+
+This gives us a multiplication table where:
+\begin{itemize}
+\item $ij = k$, but $ji = -k$
+\item $jk = i$, but $kj = -i$  
+\item $ki = j$, but $ik = -j$
+\end{itemize}
+
+Notice every element except $±1$ has order $4$, and the group is non-abelian despite being relatively small.
+\end{examplebox}
+
+\subsection{\textcolor{HeaderColor}{Alternating Groups $A_n$}}
+
+\begin{examplebox}
+Inside $S_n$, there's a special subgroup $A_n$ consisting of all \textbf{even permutations} (products of an even number of transpositions).
+
+For $A_3$: The even permutations in $S_3$ are $\{e, (123), (132)\}$. This gives us a cyclic subgroup of order $3$.
+
+For larger $n$, $A_n$ has order $\frac{n!}{2}$ and plays a crucial role in understanding why quintic equations can't be solved by radicals!
+\end{examplebox}
+
+\section{\textcolor{SectionColor}{Practice Problems - Test Your Understanding!}}
+
+\begin{enumerate}
+\item \textbf{Basic Verification:} Show that $\{0, 3, 6, 9\}$ under addition modulo $12$ forms a group. What's its structure?
+
+\item \textbf{Subgroup Hunt:} List ALL cosets of $H = \{0, 2, 4\}$ in $\mathbb{Z}_6$. What's the index $[\mathbb{Z}_6 : H]$?
+
+\item \textbf{Non-Example Analysis:} Explain why $\{(12), (13)\}$ cannot be a subgroup of $S_3$. What goes wrong?
+
+\item \textbf{Order Calculations:} Find the order of each element in $\mathbb{Z}_8$. Which elements generate the whole group?
+
+\item \textbf{Matrix Challenge:} Consider the set of matrices $\left\{\begin{bmatrix} 1 & a \\ 0 & 1 \end{bmatrix} : a \in \mathbb{R}\right\}$ under matrix multiplication. Is this a group? If so, is it abelian?
+
+\item \textbf{Lagrange Application:} A group has order $20$. What are the possible orders of its elements? What are the possible orders of its subgroups?
+
+\item \textbf{Advanced Challenge:} Prove that any finite subgroup of $(\mathbb{R}^*, \times)$ must be cyclic. (Hint: Use the fact that a polynomial of degree $n$ has at most $n$ roots.)
+\end{enumerate}
+
+\section{\textcolor{SectionColor}{Looking Forward: What's Next?}}
+
+Congratulations! You've just completed your first journey through the fundamentals of group theory. But this is just the beginning. Here's what lies ahead:
+
+\begin{itemize}
+\item \textbf{\textcolor{KeyTermColor}{Group Homomorphisms}}: Structure-preserving maps between groups
+\item \textbf{\textcolor{KeyTermColor}{Quotient Groups}}: What happens when we ``mod out'' by a normal subgroup
+\item \textbf{\textcolor{KeyTermColor}{The Isomorphism Theorems}}: Fundamental relationships between groups
+\item \textbf{\textcolor{KeyTermColor}{Group Actions}}: How groups can act on sets and other mathematical objects
+\item \textbf{\textcolor{KeyTermColor}{Sylow Theorems}}: Deep results about the existence and structure of certain subgroups
+\item \textbf{\textcolor{KeyTermColor}{Classification of Finite Groups}}: The massive project to understand all finite groups
+\end{itemize}
+
+\section{\textcolor{SectionColor}{Final Thoughts: Why Groups Matter}}
+
+You might be wondering: ``Why should I care about groups? When will I ever use this?''
+
+The answer is: Groups are everywhere! They appear in:
+
+\begin{itemize}
+\item \textbf{\textcolor{KeyTermColor}{Physics}}: Symmetries of physical systems, crystal structures, particle physics
+\item \textbf{\textcolor{KeyTermColor}{Chemistry}}: Molecular symmetries, chemical bonding
+\item \textbf{\textcolor{KeyTermColor}{Computer Science}}: Cryptography, error-correcting codes, algorithm analysis
+\item \textbf{\textcolor{KeyTermColor}{Art and Music}}: Analyzing patterns, symmetries in design, mathematical music theory
+\item \textbf{\textcolor{KeyTermColor}{Geometry}}: Understanding transformations, studying geometric objects
+\item \textbf{\textcolor{KeyTermColor}{Number Theory}}: Solving Diophantine equations, understanding algebraic structures
+\end{itemize}
+
+More importantly, group theory teaches you to think abstractly – to see the underlying patterns that connect seemingly different areas of mathematics. Once you truly understand groups, you'll start seeing their influence everywhere in mathematics and beyond.
+
+\begin{center}
+\large\textit{\textcolor{richpurple}{``The essence of mathematics lies in its freedom to create abstractions that reveal the hidden unity underlying diverse phenomena.''}}
+\end{center}
+
+Remember: mathematics is not just about computation – it's about understanding structure, pattern, and the beautiful connections that bind our universe together. Group theory is one of the most elegant examples of this principle in action.
+
+\textcolor{deepmintgreen}{\textbf{Welcome to the wonderful world of abstract algebra!}}
 
 \end{document}

--- a/introduction_to_group_theory.tex
+++ b/introduction_to_group_theory.tex
@@ -1,28 +1,226 @@
-\documentclass{article}
-\usepackage{amsmath,amssymb}
+\documentclass[12pt]{article}
+\usepackage{amsmath,amssymb,amsfonts}
+\usepackage{xcolor}
+\usepackage{tcolorbox}
+\usepackage{hyperref}
+\tcbset{colback=white,colframe=black}
+\newtcolorbox{definitionbox}[1]{colback=blue!5!white,colframe=blue!75!black,title=\textbf{#1}}
+\newtcolorbox{examplebox}[1]{colback=green!5!white,colframe=green!60!black,title=\textbf{#1}}
+\newtcolorbox{warnbox}[1]{colback=red!5!white,colframe=red!60!black,title=\textbf{#1}}
 
-\title{Introduction to Group Theory}
+\title{From Zero to Lagrange\\\small A Friendly Introduction to Group Theory}
 \author{}
 \date{}
 
 \begin{document}
 \maketitle
 
-\section{Groups}
-A \emph{group} $(G,\cdot)$ consists of a set $G$ equipped with a binary operation $\cdot$ such that the following axioms hold:
-\begin{enumerate}
-  \item \textbf{Associativity:} $(a\cdot b)\cdot c = a\cdot(b\cdot c)$ for all $a,b,c\in G$.
-  \item \textbf{Identity:} There exists an element $e\in G$ such that $e\cdot a = a\cdot e = a$ for all $a\in G$.
-  \item \textbf{Inverse:} For each $a\in G$ there exists $b\in G$ such that $a\cdot b = b\cdot a = e$.
-\end{enumerate}
-
-\section{Examples}
+\section*{Introduction: What You Need}
+\begin{definitionbox}{Starting Point}
+To talk about groups, you begin with:
 \begin{itemize}
-  \item The integers $(\mathbb{Z}, +)$ form a group under addition with identity element $0$.
-  \item The set of $n\times n$ invertible real matrices $\mathrm{GL}_n(\mathbb{R})$ is a group under matrix multiplication.
-  \item The symmetric group $S_3$ consists of all permutations of three objects.
+  \item a set $G$,
+  \item a binary rule $\star$ that takes $a,b$ in $G$ and returns $a\star b$ in $G$,
+  \item four checks: \textcolor{blue}{closure}, \textcolor{blue}{associativity}, \textcolor{blue}{identity}, and \textcolor{blue}{inverses}.
+\end{itemize}
+\end{definitionbox}
+
+\section*{Definition: Group}
+\begin{definitionbox}{What is a Group?}
+A pair $(G,\star)$ is a \textcolor{blue}{group} if for all $a,b,c\in G$:
+\begin{enumerate}
+  \item \textbf{Closure:} $a\star b$ is in $G$.
+  \item \textbf{Associativity:} $(a\star b)\star c = a\star(b\star c)$.
+  \item \textbf{Identity:} there exists $e$ with $e\star a = a\star e = a$.
+  \item \textbf{Inverse:} each $a$ has $a^{-1}$ with $a\star a^{-1} = a^{-1}\star a = e$.
+\end{enumerate}
+The group is \textcolor{purple}{abelian} if $a\star b = b\star a$ for all $a,b$.
+\end{definitionbox}
+
+\section*{How to Prove ``This is a Group"}
+\begin{examplebox}{Group Proof Recipe}
+\begin{enumerate}
+  \item Describe $G$ and the operation $\star$.
+  \item Show \textcolor{blue}{closure}.
+  \item Use known \textcolor{blue}{associativity} (for $+$ or $\times$) or compute directly.
+  \item Give the \textcolor{blue}{identity} element.
+  \item For any $a$, find $a^{-1}$ and check it works.
+\end{enumerate}
+\end{examplebox}
+
+\section*{Worked Examples: Groups and Non-Examples}
+\begin{examplebox}{1. $(\mathbb{Z}, +)$}
+Closure: $m+n$ is an integer. Identity: $0$. Inverse of $m$ is $-m$. This group is abelian.
+\end{examplebox}
+
+\begin{examplebox}{2. $(\mathbb{Z}_n, +\ \text{mod}\ n)$}
+Elements: $\{0,1,\dots,n-1\}$. Operation: addition mod $n$. Identity: $0$. Inverse of $k$ is $n-k$. Abelian.
+\textit{Example:} in $\mathbb{Z}_6$, $4+5\equiv3$ and the inverse of $4$ is $2$.
+\end{examplebox}
+
+\begin{examplebox}{3. $(\mathbb{Q}^*,\times)$ and $(\mathbb{R}^*,\times)$}
+Identity: $1$. Inverse of $a/b$ is $b/a$. Both are abelian.
+\end{examplebox}
+
+\begin{examplebox}{4. $\mathrm{GL}_2(\mathbb{R})$}
+$2\times2$ invertible real matrices under multiplication. Identity is $I=\begin{bmatrix}1&0\\0&1\end{bmatrix}$. Inverses are usual matrix inverses. Generally non-abelian. For example,\[\begin{bmatrix}1&1\\0&1\end{bmatrix}\begin{bmatrix}1&0\\1&1\end{bmatrix}=\begin{bmatrix}2&1\\1&1\end{bmatrix} \neq \begin{bmatrix}1&0\\1&1\end{bmatrix}\begin{bmatrix}1&1\\0&1\end{bmatrix}=\begin{bmatrix}1&1\\1&2\end{bmatrix}.\]
+\end{examplebox}
+
+\begin{examplebox}{5. Symmetric Group $S_3$}
+Six permutations of $\{1,2,3\}$ with composition. Non-abelian: $(12)\circ(23) \neq (23)\circ(12)$. Example: $(12)(23)=(123)$.
+\end{examplebox}
+
+\begin{examplebox}{6. Dihedral Group $D_4$}
+Symmetries of a square: four rotations and four reflections. Non-abelian.
+\end{examplebox}
+
+\begin{examplebox}{7. Klein Four Group $V_4$}
+Elements $\{e,a,b,c\}$ with $a^2=b^2=c^2=e$ and $ab=c$, $bc=a$, $ca=b$. Abelian but not cyclic.
+\end{examplebox}
+
+\begin{warnbox}{Non-Examples}
+\begin{itemize}
+  \item $(\mathbb{N},+)$ fails inverses.
+  \item $(\mathbb{Z},\times)$ fails inverses for most elements.
+  \item $(\mathbb{R},-)$ fails associativity.
+\end{itemize}
+\end{warnbox}
+
+\section*{Basic Concepts You Will Use Soon}
+\begin{definitionbox}{Key Ideas}
+\begin{itemize}
+  \item \textbf{Order of an element} $a$: smallest $k>0$ with $a^k=e$ (or $k\cdot a=0$ in additive groups).
+  \item \textbf{Cyclic group:} a group generated by one element $g$.
+  \item \textbf{Order of a group:} number of elements $|G|$ if finite.
+\end{itemize}
+\end{definitionbox}
+
+\section*{Subgroups}
+\begin{definitionbox}{What is a Subgroup?}
+A nonempty subset $H$ of $G$ is a \textcolor{blue}{subgroup} if for all $a,b\in H$, the element $a\star b^{-1}$ is also in $H$. For additive groups replace $a\star b^{-1}$ by $a-b$.
+\end{definitionbox}
+
+\subsection*{Quick Subgroup Facts}
+\begin{itemize}
+  \item The identity $e$ lies in every subgroup.
+  \item If $a\in H$ then $a^{-1}\in H$.
+  \item Intersections of subgroups are subgroups.
+  \item The subgroup generated by $S$ is $\langle S\rangle$.
 \end{itemize}
 
-\section{Subgroups}
-A \emph{subgroup} $H$ of a group $G$ is a subset of $G$ that is itself a group under the operation of $G$.
+\subsection*{Worked Examples: Subgroups}
+\begin{examplebox}{1. $k\mathbb{Z} \leq \mathbb{Z}$}
+$k\mathbb{Z}=\{\ldots,-2k,-k,0,k,2k,\ldots\}$ is closed under subtraction, so it is a subgroup. Examples include even integers $2\mathbb{Z}$.
+\end{examplebox}
+
+\begin{examplebox}{2. Subgroups of $\mathbb{Z}_6$ under $+$}
+Every subgroup is $\langle d\rangle$ where $d$ divides $6$. They are $\{0\}$, $\{0,3\}$, $\{0,2,4\}$, and $\mathbb{Z}_6$. The subset $T=\{0,2\}$ fails because $2+2=4\notin T$.
+\end{examplebox}
+
+\begin{examplebox}{3. Subgroups of $S_3$}
+Possible sizes: $1,2,3,6$. Subgroups: $\{e\}$; three generated by transpositions $\langle(12)\rangle$, $\langle(13)\rangle$, $\langle(23)\rangle$; the order-3 subgroup $A_3=\langle(123)\rangle$; and $S_3$ itself.
+\end{examplebox}
+
+\begin{examplebox}{4. Center $Z(G)$}
+$Z(G)=\{g\in G: gx=xg \text{ for all } x\in G\}$ is a subgroup.
+\end{examplebox}
+
+\begin{examplebox}{5. Rotation Subgroup of $D_4$}
+$R=\{e,r,r^2,r^3\}$ with $r$ a $90^\circ$ rotation is a subgroup of order $4$.
+\end{examplebox}
+
+\begin{examplebox}{6. Upper Triangular Matrices}
+Invertible upper triangular matrices form a subgroup of $\mathrm{GL}_2(\mathbb{R})$.
+\end{examplebox}
+
+\section*{Cosets and Index}
+\begin{definitionbox}{Cosets}
+For $H\leq G$ and $g\in G$:
+\begin{itemize}
+  \item Left coset: $gH=\{g\star h: h\in H\}$.
+  \item Right coset: $Hg=\{h\star g: h\in H\}$.
+\end{itemize}
+Cosets are the same size as $H$, either equal or disjoint, and they partition $G$. The \textbf{index} $[G:H]$ counts the left cosets.
+\end{definitionbox}
+
+\subsection*{Coset Examples}
+\begin{examplebox}{1. $\mathbb{Z}_6$ with $H=\{0,3\}$}
+Cosets: $\{0,3\}$, $\{1,4\}$, $\{2,5\}$. Each has two elements, so $[\mathbb{Z}_6:H]=3$.
+\end{examplebox}
+
+\begin{examplebox}{2. $S_3$ with $H=\langle(12)\rangle$}
+Cosets: $H$, $(13)H=\{(13),(132)\}$, $(23)H=\{(23),(123)\}$. Again $[S_3:H]=3$.
+\end{examplebox}
+
+\section*{Lagrange's Theorem}
+\begin{definitionbox}{Statement}
+If $G$ is finite and $H\leq G$, then $|G|=[G:H]\cdot|H|$. Hence $|H|$ divides $|G|$.
+\end{definitionbox}
+
+\begin{examplebox}{Why It Works}
+$G$ breaks into disjoint cosets $g_1H,\dots,g_kH$. Each has $|H|$ elements, so $|G|=k\cdot|H|$ with $k=[G:H]$.
+\end{examplebox}
+
+\subsection*{Key Corollaries}
+\begin{itemize}
+  \item \textbf{Order of an element divides $|G|$.} If $a\in G$, then $|\langle a\rangle|$ divides $|G|$, so $a^{|G|}=e$ in finite groups.
+  \item \textbf{Groups of prime order are cyclic.}
+  \item \textbf{Fermat's little theorem:} in $U_p=\{1,2,\dots,p-1\}$ under multiplication mod $p$, $a^{p-1}\equiv1\pmod p$.
+\end{itemize}
+
+\subsection*{Worked Applications}
+\begin{examplebox}{1. Subgroup Sizes of $S_3$}
+Divisors of $6$ are $1,2,3,6$; no subgroup of size $4$ or $5$ exists.
+\end{examplebox}
+
+\begin{examplebox}{2. Orders in $\mathbb{Z}_{12}$ under $+$}
+Orders divide $12$: $\operatorname{ord}(1)=12$, $\operatorname{ord}(2)=6$, $\operatorname{ord}(3)=4$, $\operatorname{ord}(4)=3$, $\operatorname{ord}(6)=2$, $\operatorname{ord}(0)=1$.
+\end{examplebox}
+
+\begin{examplebox}{3. No element of order $6$ in $S_3$}
+Allowed by Lagrange, but actual element orders are only $1,2,$ or $3$.
+\end{examplebox}
+
+\begin{examplebox}{4. Index in $\mathbb{Z}_{12}$}
+For $H=\langle4\rangle=\{0,4,8\}$, $|H|=3$ and $[\mathbb{Z}_{12}:H]=4$. Cosets are $\{0,4,8\}$, $\{1,5,9\}$, $\{2,6,10\}$, $\{3,7,11\}$.
+\end{examplebox}
+
+\section*{Common Pitfalls}
+\begin{warnbox}{Be Careful!}
+\begin{itemize}
+  \item Closure is more than being nonempty.
+  \item Many groups are not abelian.
+  \item ``Divides" does not guarantee existence.
+  \item Every subgroup must contain the identity.
+\end{itemize}
+\end{warnbox}
+
+\section*{Mini Checklists}
+\begin{examplebox}{Testing a Subgroup}
+\begin{itemize}
+  \item Nonempty?
+  \item For all $a,b\in H$, is $ab^{-1}$ in $H$?
+\end{itemize}
+\end{examplebox}
+
+\begin{examplebox}{Computing Cosets}
+\begin{itemize}
+  \item Pick a representative $g$.
+  \item Form $gH=\{gh:h\in H\}$.
+  \item Repeat with elements not yet used.
+\end{itemize}
+\end{examplebox}
+
+\section*{Quick Practice}
+\begin{itemize}
+  \item Is $\{0,3,6,9\}$ a subgroup of $\mathbb{Z}_{12}$ under $+$?
+  \item List all cosets of $H=\{0,2,4\}$ in $\mathbb{Z}_6$.
+  \item In $S_3$, why is $\{(12),(13)\}$ not a subgroup?
+  \item Find $\operatorname{ord}(2)$ in $\mathbb{Z}_8$ and list $\langle2\rangle$.
+  \item Show every finite subgroup of $(\mathbb{R}^*,\times)$ is cyclic.
+\end{itemize}
+
+\section*{Summary}
+Groups require \textcolor{blue}{closure}, \textcolor{blue}{associativity}, an \textcolor{blue}{identity}, and \textcolor{blue}{inverses}. Subgroups pass the test $ab^{-1}\in H$. Cosets split the group into equal pieces, leading to \textcolor{purple}{Lagrange's Theorem}: $|G|=[G:H]\cdot|H|$. These tools classify small groups, compute orders, and prove number theory facts.
+
 \end{document}


### PR DESCRIPTION
## Summary
- add LaTeX document introducing basic group theory concepts

## Testing
- `pdflatex introduction_to_group_theory.tex`

------
https://chatgpt.com/codex/tasks/task_e_689c0fc6000c8331bd0bb438a201db27