### PR TITLE
Add Sylow Theorems LaTeX document

### DIFF
--- a/sylow.tex
+++ b/sylow.tex
@@ -1,0 +1,972 @@
+\documentclass[12pt,a4paper]{article}
+
+% ---- Standard Packages ----
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}          % A clean, modern font for PDFLaTeX
+\usepackage[margin=1in,headheight=13.6pt]{geometry} % Standard 1-inch margins
+\usepackage{microtype}        % Improves character and word spacing
+\usepackage{amsmath,amssymb,amsthm,mathtools} % Essential math packages
+\usepackage{enumitem}         % For customized lists
+\usepackage{graphicx}         % For including images
+\usepackage{wrapfig}          % To wrap text around figures
+\usepackage{hyperref}         % Clickable links and references
+\hypersetup{
+    colorlinks=true,
+    linkcolor=blue,
+    filecolor=magenta,      
+    urlcolor=cyan,
+    pdftitle={Sylow's Theorems},
+    pdfpagemode=FullScreen,
+}
+
+% ---- Document Layout and Rhythm ----
+\setlength{\parindent}{0pt}   % No indentation for new paragraphs
+\setlength{\parskip}{0.8em}    % Space between paragraphs
+\setlist{itemsep=5pt, topsep=5pt, partopsep=0pt} % Spacing within lists
+
+% ---- Custom Commands ----
+\newcommand{\tick}{\ensuremath{\checkmark}} % A checkmark for lists
+
+% ---- Theorem-like Environments ----
+% We define different styles for theorems, definitions, and remarks for clarity.
+\theoremstyle{plain} % Italicized text, extra space above and below.
+\newtheorem{theorem}{Theorem}[section]
+\newtheorem{lemma}[theorem]{Lemma}
+\newtheorem{corollary}[theorem]{Corollary}
+\newtheorem{proposition}[theorem]{Proposition}
+
+\theoremstyle{definition} % Upright text, extra space above and below.
+\newtheorem{definition}[theorem]{Definition}
+\newtheorem{example}[theorem]{Example}
+\newtheorem{strategy}[theorem]{Strategy}
+
+\theoremstyle{remark} % Upright text, no extra space.
+\newtheorem*{remark}{Remark}
+\newtheorem*{note}{A Quick Note}
+
+% ---- Math Operators ----
+% Defining operators ensures consistent formatting and spacing.
+\DeclareMathOperator{\Syl}{Syl}
+\DeclareMathOperator{\Stab}{Stab}
+\DeclareMathOperator{\Orb}{Orb}
+\DeclareMathOperator{\Aut}{Aut}
+\DeclareMathOperator{\Inn}{Inn}
+\DeclareMathOperator{\Ker}{Ker}
+\DeclareMathOperator{\im}{im} % 'im' for image
+\DeclareMathOperator{\lcm}{lcm}
+
+% ====================================================================
+%                          DOCUMENT START
+% ====================================================================
+\begin{document}
+
+% ---- Title Page ----
+\begin{center}
+  {\Huge\bfseries The Sylow Theorems: A Guide to Finite Group Structure}\\[-2pt]
+  \rule{0.95\textwidth}{1.2pt}\\[4pt]
+  {\Large A comprehensive, example-driven journey into the heart of finite group theory}
+\end{center}
+
+\section*{To the Student: Your Compass in the World of Finite Groups}
+
+Welcome! You're about to explore one of the most powerful and elegant set of tools in abstract algebra: the **Sylow Theorems**. Imagine you're an explorer given a map of a vast, unknown territory—the world of finite groups. This territory is populated by groups of every conceivable size. Your map is incomplete, but you have a special compass. This compass doesn't point north; instead, it points to special subgroups, the **Sylow $p$-subgroups**.
+
+What's the big idea? The fundamental theorem of arithmetic tells us that any integer can be uniquely factored into primes. This "prime decomposition" is the key to understanding integers. The Sylow theorems provide a partial, but incredibly powerful, analogue for finite groups. They guarantee the existence of subgroups of prime-power order and give us strict arithmetic rules governing how many of them there are.
+
+By using this "compass," we can:
+\begin{itemize}[label=\textbf{--}]
+  \item \textbf{Find Structure:} Guarantee the existence of certain subgroups, which act as the building blocks of the larger group.
+  \item \textbf{Rule Out Possibilities:} Prove that no group with a certain structure can exist (for example, we can prove that there are no simple groups of many orders).
+  \item \textbf{Deconstruct Groups:} Show how a large, complicated group might be "built" from smaller, more manageable pieces using products.
+  \item \textbf{Identify "Royalty":} Find **normal subgroups**, which are the most important and well-behaved type of subgroup. Finding a non-trivial normal subgroup is the first step to breaking a group down, much like finding a divisor is the first step to factoring an integer.
+\end{itemize}
+
+These notes are designed to be your guide. We will move slowly and deliberately, building up our toolkit piece by piece. We'll start with the foundational concepts of how subgroups interact, then review the language of group actions, and finally, dive into the theorems themselves. The real magic happens in the applications, where we'll use these theorems to dissect groups of specific orders and reveal their inner workings.
+
+So, grab your explorer's hat, and let's begin our adventure!
+
+\vfill
+\begin{center}
+\rule{0.5\textwidth}{0.4pt}
+\end{center}
+\vfill
+
+\tableofcontents
+\newpage
+
+% ====================================================================
+\section{Preparing the Ground: How Subgroups Interact}
+% ====================================================================
+
+Before we can use the Sylow theorems to find special subgroups, we need to understand how subgroups, in general, relate to one another. Specifically, if we have two subgroups, $H$ and $K$, of a group $G$, what can we say about the set of all possible products of their elements?
+
+\begin{definition}[The Product Set $HK$]
+Let $H$ and $K$ be subgroups of a group $G$. We define the **product set** $HK$ as the set of all possible products of an element from $H$ followed by an element from $K$:
+\[
+HK = \{ hk \mid h \in H, k \in K \}
+\]
+\end{definition}
+
+\begin{remark}
+\textbf{A word of caution!} Even though $H$ and $K$ are subgroups, the set $HK$ is **not always a subgroup**. The issue is closure. If we take two elements from $HK$, say $h_1k_1$ and $h_2k_2$, their product is $(h_1k_1)(h_2k_2) = h_1(k_1h_2)k_2$. For this to be in the form `(element of H)(element of K)`, we need to be able to swap $k_1h_2$ into something like $h'k'$. This isn't always possible.
+\end{remark}
+
+\begin{example}[When $HK$ is Not a Subgroup]
+Consider the symmetric group $G = S_3 = \{e, (12), (13), (23), (123), (132)\}$.
+Let $H = \{e, (12)\}$ and $K = \{e, (13)\}$. Both are subgroups of order 2.
+Let's compute the product set $HK$:
+\[
+HK = \{e \cdot e, e \cdot (13), (12) \cdot e, (12) \cdot (13)\} = \{e, (13), (12), (123)\}
+\]
+This set has 4 elements. Since 4 does not divide $|S_3|=6$, by Lagrange's Theorem, $HK$ cannot be a subgroup of $S_3$. We can also see it fails closure: $(13) \in HK$ and $(12) \in HK$, but their product $(13)(12)=(132)$ is not in $HK$.
+\end{example}
+
+So, when *is* $HK$ a subgroup? The following proposition gives us the exact condition.
+
+\begin{proposition}[The Subgroup Condition for $HK$]
+Let $H$ and $K$ be subgroups of $G$. The set $HK$ is a subgroup of $G$ if and only if $HK = KH$.
+\end{proposition}
+
+\begin{proof}
+$(\Rightarrow)$ Assume $HK$ is a subgroup. We want to show $HK=KH$.
+\begin{itemize}
+    \item \textbf{Show $KH \subseteq HK$:} Let $kh \in KH$ be an arbitrary element. Since $HK$ is a subgroup, it is closed under inverses. The element $kh$ has an inverse, $(kh)^{-1} = h^{-1}k^{-1}$. Since $h \in H$ and $k \in K$, we have $h^{-1} \in H$ and $k^{-1} \in K$. Thus, the product $h^{-1}k^{-1}$ is an element of $HK$. Since $HK$ is a subgroup, the inverse of this element, $(h^{-1}k^{-1})^{-1} = kh$, must also be in $HK$. Therefore, $KH \subseteq HK$.
+
+    \item \textbf{Show $HK \subseteq KH$:} Let $hk \in HK$. Since $HK$ is a subgroup, its inverse $(hk)^{-1} = k^{-1}h^{-1}$ must also be in $HK$. But $k^{-1}h^{-1}$ is clearly an element of $KH$. So we have an element of $KH$ that is in $HK$. This isn't quite what we need. Let's try a different approach. Let $x \in HK$. Then $x^{-1} \in HK$ since $HK$ is a subgroup. So $x^{-1} = h_1k_1$ for some $h_1 \in H, k_1 \in K$. Then $x = (h_1k_1)^{-1} = k_1^{-1}h_1^{-1}$. This is an element of $KH$. So $HK \subseteq KH$.
+\end{itemize}
+Combining both inclusions, we get $HK = KH$.
+
+$(\Leftarrow)$ Assume $HK=KH$. We use the one-step subgroup test.
+\begin{enumerate}
+    \item \textbf{Identity:} $e = e \cdot e \in HK$. So $HK$ is non-empty.
+    \item \textbf{Closure:} Let $x_1, x_2 \in HK$. So $x_1=h_1k_1$ and $x_2=h_2k_2$. We need to show their product $x_1x_2$ is in $HK$.
+    \[
+    x_1x_2 = (h_1k_1)(h_2k_2) = h_1(k_1h_2)k_2
+    \]
+    The term in the middle, $k_1h_2$, is an element of $KH$. By our assumption, $KH=HK$, so there must exist some $h' \in H$ and $k' \in K$ such that $k_1h_2 = h'k'$.
+    Substituting this back in:
+    \[
+    x_1x_2 = h_1(h'k')k_2 = (h_1h') (k'k_2)
+    \]
+    Since $h_1h' \in H$ (closure in H) and $k'k_2 \in K$ (closure in K), the entire product is in $HK$.
+    \item \textbf{Inverses:} Let $x = hk \in HK$. We need to show $x^{-1} \in HK$.
+    \[
+    x^{-1} = (hk)^{-1} = k^{-1}h^{-1}
+    \]
+    This is an element of $KH$. But since $KH=HK$, we know $k^{-1}h^{-1}$ must also be in $HK$.
+\end{enumerate}
+Since $HK$ contains the identity, is closed under multiplication, and contains inverses, it is a subgroup of $G$.
+\end{proof}
+
+This condition $HK=KH$ is great, but checking it can be a pain. Luckily, there's a very common situation where it's automatically true.
+
+\begin{lemma}[Normality Makes Products Subgroups]
+Let $H, K$ be subgroups of $G$. If $H$ is a normal subgroup of $G$ (written $H \unlhd G$) or if $K$ is a normal subgroup of $G$ ($K \unlhd G$), then $HK$ is a subgroup of $G$.
+\end{lemma}
+\begin{proof}
+Suppose $H \unlhd G$. We will show that $HK=KH$, which by the previous proposition means $HK$ is a subgroup. Let $k \in K, h \in H$. We need to show that the element $kh$ can be written as an element of $HK$.
+Consider the element $khk^{-1}$. Since $H$ is normal, for any $g \in G$ (and in particular, for $g=k$), we have $gHg^{-1} = H$. This means $khk^{-1} \in H$. Let's call this element $h'$, so $h' = khk^{-1}$.
+Multiplying on the right by $k$, we get $h'k = kh$.
+So we have shown that for any $kh \in KH$, we can write it as $h'k$, which is in $HK$. Therefore, $KH \subseteq HK$.
+
+For the other direction, let $hk \in HK$. We want to show $hk \in KH$. Consider $k^{-1}hk$. Since $H$ is normal, $k^{-1}hk = h''$ for some $h'' \in H$. Then $hk = k(k^{-1}hk) = kh''$. This is in $KH$. So $HK \subseteq KH$.
+Thus $HK=KH$, and $HK$ is a subgroup. The proof is analogous if we assume $K \unlhd G$.
+\end{proof}
+
+\subsection{The Product Formula}
+Now that we know when $HK$ is a subgroup, we need to know its size. This is a crucial formula for many counting arguments in Sylow theory.
+
+\begin{theorem}[The Product Formula]
+If $H$ and $K$ are finite subgroups of a group $G$, then the size of the set $HK$ is given by:
+\[
+|HK| = \frac{|H| |K|}{|H \cap K|}
+\]
+\end{theorem}
+
+\begin{proof}
+The proof is a clever application of counting. The set $HK$ might have duplicates; that is, it's possible that $h_1k_1 = h_2k_2$ for different choices of $h_i, k_i$. We need to count exactly how many times each element is "created".
+
+Let's define a map $\mu: H \times K \to HK$ by $\mu(h,k) = hk$. This map is surjective by definition. We want to know the size of the image, which is $|HK|$. To do this, we can count the size of the domain, $|H \times K| = |H||K|$, and figure out the "collapsing factor" of the map.
+
+Let $x \in HK$ be an arbitrary element. Let's fix one representation of $x$, say $x=h_0k_0$. We want to find all other pairs $(h,k) \in H \times K$ such that $hk = x$.
+Suppose $hk = h_0k_0$. We can rearrange this equation:
+\[
+h_0^{-1}h = k_0k^{-1}
+\]
+Let's call this element $j = h_0^{-1}h = k_0k^{-1}$.
+Since $h_0, h \in H$, $j = h_0^{-1}h$ must be in $H$.
+Since $k_0, k \in K$, $j = k_0k^{-1}$ must be in $K$.
+Therefore, $j$ must lie in the intersection, $j \in H \cap K$.
+
+This gives us a way to describe all pairs $(h,k)$ that map to $x$.
+From $j=h_0^{-1}h$, we get $h = h_0j$.
+From $j=k_0k^{-1}$, we get $k^{-1}=k_0^{-1}j$, which means $k = (k_0^{-1}j)^{-1} = j^{-1}k_0$.
+So, any pair $(h,k)$ that maps to $x$ must be of the form $(h_0j, j^{-1}k_0)$ for some $j \in H \cap K$.
+
+Conversely, let's check that any such pair does indeed map to $x$:
+\[
+(h_0j)(j^{-1}k_0) = h_0(jj^{-1})k_0 = h_0ek_0 = h_0k_0 = x
+\]
+This establishes a one-to-one correspondence between the elements of the intersection $H \cap K$ and the pairs in $H \times K$ that produce the element $x$. In other words, every element in the image $HK$ is the result of exactly $|H \cap K|$ different pairs from the domain $H \times K$.
+
+Therefore, we can conclude that the total number of pairs is the number of resulting elements times the number of repetitions for each:
+\[
+|H \times K| = |HK| \cdot |H \cap K|
+\]
+\[
+|H| |K| = |HK| \cdot |H \cap K|
+\]
+Rearranging gives the desired formula: $|HK| = \frac{|H| |K|}{|H \cap K|}$.
+\end{proof}
+
+\subsection{Internal Direct Products: The Ideal Decomposition}
+The best-case scenario for group decomposition is when a group $G$ can be split into two subgroups that are almost completely independent of each other. This is formalized by the internal direct product.
+
+\begin{proposition}[Internal Direct Product]
+Let $G$ be a group with subgroups $H$ and $K$. If
+\begin{enumerate}
+    \item $H \unlhd G$ and $K \unlhd G$ (both are normal),
+    \item $H \cap K = \{e\}$ (they only intersect at the identity),
+    \item $G = HK$ (they generate the whole group),
+\end{enumerate}
+Then $G$ is isomorphic to the external direct product $H \times K$.
+\end{proposition}
+
+\begin{proof}
+We need to show that elements of $H$ commute with elements of $K$. Let $h \in H$ and $k \in K$. Consider the commutator $[h,k] = hkh^{-1}k^{-1}$.
+\begin{itemize}
+    \item Since $K \unlhd G$, we know that for any $g \in G$, $gKg^{-1} = K$. In particular, for $h \in H \subset G$, we have $hkh^{-1} \in K$. Since $k^{-1}$ is also in $K$, their product $[h,k] = (hkh^{-1})k^{-1}$ must be in $K$.
+    \item Since $H \unlhd G$, we know that for any $g \in G$, $gHg^{-1} = H$. In particular, for $k \in K \subset G$, we have $k^{-1} \in K$, so $kHk^{-1}=H$. This means $khk^{-1} \in H$. Wait, that's not right. We need to look at the other part of the commutator. $h \in H$ and $k h^{-1} k^{-1} \in H$ (since $h^{-1} \in H$ and $k \in G$). So $[h,k] = h(kh^{-1}k^{-1})$ is a product of two elements of $H$, so it is in $H$.
+\end{itemize}
+The commutator $[h,k]$ lies in both $H$ and $K$. By condition (2), $H \cap K = \{e\}$, so we must have $[h,k] = e$.
+\[
+hkh^{-1}k^{-1} = e \implies hk = kh
+\]
+So, every element of $H$ commutes with every element of $K$. Now we can define the isomorphism $\phi: H \times K \to G$ by $\phi(h,k) = hk$.
+\begin{itemize}
+    \item \textbf{It is a homomorphism}:
+    \begin{align*}
+    \phi((h_1, k_1)(h_2, k_2)) &= \phi(h_1h_2, k_1k_2) \\
+                              &= (h_1h_2)(k_1k_2) \\
+                              &= h_1(h_2k_1)k_2 \quad \text{(associativity)} \\
+                              &= h_1(k_1h_2)k_2 \quad \text{(since } h_2, k_1 \text{ commute)} \\
+                              &= (h_1k_1)(h_2k_2) \\
+                              &= \phi(h_1,k_1)\phi(h_2,k_2)
+    \end{align*}
+    \item \textbf{It is injective (has trivial kernel)}: Suppose $\phi(h,k)=e$. Then $hk=e$, so $h=k^{-1}$. But $h \in H$ and $k^{-1} \in K$. So $h$ is in $H \cap K$. By condition (2), this means $h=e$. If $h=e$, then $k^{-1}=e$, so $k=e$. The kernel is $\{(e,e)\}$, so the map is injective.
+    \item \textbf{It is surjective}: This is guaranteed by condition (3), $G=HK$.
+\end{itemize}
+Thus, $\phi$ is an isomorphism, and $G \cong H \times K$.
+\end{proof}
+
+This is our ultimate goal when analyzing a group with Sylow theory: if we can find two normal Sylow subgroups for different primes, they will have a trivial intersection (by Lagrange's theorem), and the product formula will often show they generate the whole group. This proves that $G$ is a direct product of its Sylow subgroups.
+
+\newpage
+% ====================================================================
+\section{Group Actions: A Dynamic View of Groups}
+% ====================================================================
+
+Group theory can sometimes feel static. We have sets with binary operations, and we study their properties. Group actions breathe life into it. The idea is to understand a group by seeing what it *does* to a set. This dynamic perspective turns abstract group laws into concrete permutations.
+
+\begin{definition}[Group Action]
+A (left) **action** of a group $G$ on a set $X$ is a map $\cdot: G \times X \to X$, written as $(g,x) \mapsto g \cdot x$, that satisfies two axioms for all $g, h \in G$ and all $x \in X$:
+\begin{enumerate}
+    \item \textbf{Identity:} $e \cdot x = x$ (the identity element of the group does nothing).
+    \item \textbf{Compatibility:} $g \cdot (h \cdot x) = (gh) \cdot x$ (acting by $h$ then $g$ is the same as acting by $gh$).
+\end{enumerate}
+When an action exists, we say "$G$ **acts on** $X$".
+\end{definition}
+
+\begin{example}[The Symmetric Group]
+The quintessential example of a group action is the symmetric group $S_n$ acting on the set $X = \{1, 2, \dots, n\}$. A permutation $\sigma \in S_n$ acts on an element $k \in X$ by sending it to $\sigma(k)$.
+For instance, in $S_4$, let $\sigma = (123)(4)$. Then $\sigma \cdot 1 = 2$, $\sigma \cdot 2 = 3$, $\sigma \cdot 3 = 1$, and $\sigma \cdot 4 = 4$.
+\end{example}
+
+\subsection{Key Concepts of Group Actions}
+For any action of $G$ on $X$, we have two fundamental concepts that help us break down the action's structure.
+
+\begin{definition}[Orbit]
+The **orbit** of an element $x \in X$ under the action of $G$ is the set of all points that $x$ can be moved to by elements of $G$.
+\[
+\Orb_G(x) = \{ g \cdot x \mid g \in G \}
+\]
+The orbits partition the set $X$ into disjoint equivalence classes (where $x \sim y$ if $y = g \cdot x$ for some $g$).
+\end{definition}
+
+\begin{definition}[Stabilizer]
+The **stabilizer** of an element $x \in X$ is the set of all group elements that leave $x$ fixed.
+\[
+\Stab_G(x) = \{ g \in G \mid g \cdot x = x \}
+\]
+The stabilizer $\Stab_G(x)$ is always a subgroup of $G$. (Proof: $e \cdot x = x$, so $e \in \Stab_G(x)$. If $g, h \in \Stab_G(x)$, then $(gh)\cdot x = g \cdot (h \cdot x) = g \cdot x = x$, so $gh \in \Stab_G(x)$. If $g \in \Stab_G(x)$, then $g \cdot x = x$, so $g^{-1} \cdot (g \cdot x) = g^{-1} \cdot x$, which means $x = g^{-1} \cdot x$, so $g^{-1} \in \Stab_G(x)$.)
+\end{definition}
+
+These two concepts are beautifully linked by a central result in group theory.
+
+\begin{theorem}[The Orbit-Stabilizer Theorem]
+Let a finite group $G$ act on a set $X$. For any $x \in X$:
+\[
+|G| = |\Orb_G(x)| \cdot |\Stab_G(x)|
+\]
+In words: the order of the group is the product of the size of an element's orbit and the size of its stabilizer. This implies that the size of any orbit must divide the order of the group.
+\end{theorem}
+\begin{proof}
+Let $H = \Stab_G(x)$. We will show there is a bijection between the orbit of $x$ and the set of left cosets of $H$ in $G$, denoted $G/H$.
+Define a map $\psi: G/H \to \Orb_G(x)$ by $\psi(gH) = g \cdot x$.
+\begin{itemize}
+    \item \textbf{Well-defined:} We need to show that if we pick a different representative for the coset, we get the same result. Suppose $g_1H = g_2H$. This means $g_1 = g_2h$ for some $h \in H = \Stab_G(x)$. We must check if $\psi(g_1H) = \psi(g_2H)$.
+    \[
+    \psi(g_1H) = g_1 \cdot x = (g_2h) \cdot x = g_2 \cdot (h \cdot x)
+    \]
+    Since $h \in \Stab_G(x)$, we have $h \cdot x = x$. So,
+    \[
+    g_2 \cdot (h \cdot x) = g_2 \cdot x = \psi(g_2H)
+    \]
+    The map is well-defined.
+    \item \textbf{Surjective:} Let $y$ be any element in the orbit of $x$. By definition, this means $y = g \cdot x$ for some $g \in G$. Then the coset $gH$ is mapped to $y$ by $\psi$. So $\psi$ is surjective.
+    \item \textbf{Injective:} Suppose $\psi(g_1H) = \psi(g_2H)$. This means $g_1 \cdot x = g_2 \cdot x$.
+    Acting on both sides by $g_2^{-1}$:
+    \[
+    g_2^{-1} \cdot (g_1 \cdot x) = g_2^{-1} \cdot (g_2 \cdot x)
+    \]
+    \[
+    (g_2^{-1}g_1) \cdot x = (g_2^{-1}g_2) \cdot x = e \cdot x = x
+    \]
+    This says that the element $g_2^{-1}g_1$ fixes $x$. By definition, this means $g_2^{-1}g_1 \in \Stab_G(x) = H$.
+    If $g_2^{-1}g_1 \in H$, this is the definition of $g_1H = g_2H$. So the map is injective.
+\end{itemize}Since we have a bijection between $G/H$ and \Orb_G(x), they must have the same size.
+\[
+|\Orb_G(x)| = |G/H| = \frac{|G|}{|H|} = \frac{|G|}{|\Stab_G(x)|}
+\]
+Rearranging this gives the theorem.
+\end{proof}
+
+\subsection{The Action-Homomorphism Link}
+Every group action gives rise to a homomorphism, and this is the key to using actions to find normal subgroups.
+
+\begin{proposition}[The Permutation Representation]
+An action of a group $G$ on a set $X$ with $|X|=n$ defines a homomorphism $\phi: G \to S_X \cong S_n$.
+The kernel of this homomorphism is the **kernel of the action**, given by:
+\[
+\Ker(\phi) = \bigcap_{x \in X} \Stab_G(x)
+\]
+This kernel is the set of all elements in $G$ that fix *every* element of $X$.
+\end{proposition}
+\begin{proof}
+For each $g \in G$, define a function $\sigma_g: X \to X$ by $\sigma_g(x) = g \cdot x$. This function is a permutation (a bijection) because it has an inverse, $\sigma_{g^{-1}}$. The map $\phi: G \to S_X$ given by $\phi(g) = \sigma_g$ is a homomorphism because $\sigma_{gh}(x) = (gh)\cdot x = g \cdot (h \cdot x) = \sigma_g(\sigma_h(x)) = (\sigma_g \circ \sigma_h)(x)$, so $\phi(gh) = \phi(g)\phi(h)$.
+
+The kernel of this homomorphism is the set of $g \in G$ such that $\phi(g)$ is the identity permutation in $S_X$. The identity permutation is the one that fixes every element. So, $g \in \Ker(\phi)$ if and only if $\sigma_g(x) = x$ for all $x \in X$. This is equivalent to $g \cdot x = x$ for all $x \in X$, which means $g$ must be in the stabilizer of every $x \in X$.
+\end{proof}
+
+\begin{corollary}[Actions and Normality]
+The kernel of any group action is a normal subgroup of $G$.
+\end{corollary}
+\begin{proof}
+The kernel of any homomorphism is always a normal subgroup.
+\end{proof}
+
+This is a profoundly important tool. If we can define a clever action of $G$ on some set $X$, and if we can show that the kernel of this action is not just $\{e\}$ and not the whole group $G$, then we have found a non-trivial proper normal subgroup, which proves that $G$ is not simple.
+
+\subsection{The Most Important Action: Conjugation}
+For the Sylow theorems, the most important action is the action of a group on itself or its subgroups by conjugation.
+
+\begin{definition}[Conjugation Action]
+A group $G$ acts on itself as a set ($X=G$) by **conjugation**:
+\[
+g \cdot x = gxg^{-1} \quad \text{for } g,x \in G
+\]
+In this action:
+\begin{itemize}
+    \item The orbit of $x$ is its **conjugacy class**, $C(x) = \{gxg^{-1} \mid g \in G\}$.
+    \item The stabilizer of $x$ is its **centralizer**, $C_G(x) = \{g \in G \mid gx=xg\}$.
+\end{itemize}
+The Orbit-Stabilizer theorem becomes $|G| = |C(x)| \cdot |C_G(x)|$.
+
+A group $G$ also acts on the set of all its subgroups, $\mathcal{S}$, by conjugation:
+\[
+g \cdot H = gHg^{-1} = \{ghg^{-1} \mid h \in H\} \quad \text{for } g \in G, H \in \mathcal{S}
+\]
+In this action:
+\begin{itemize}
+    \item The orbit of a subgroup $H$ is the set of all subgroups conjugate to $H$.
+    \item The stabilizer of a subgroup $H$ is its **normalizer**, $N_G(H) = \{g \in G \mid gHg^{-1}=H\}$.
+\end{itemize}
+The Orbit-Stabilizer theorem becomes $|G| = |\text{Orbit}(H)| \cdot |N_G(H)|$. The size of the orbit is the number of distinct subgroups conjugate to $H$, which is the index of the normalizer: $[G : N_G(H)]$.
+\end{definition}
+
+A subgroup $H$ is normal in $G$ if and only if its conjugacy class has size 1, which is equivalent to its normalizer being the whole group, $N_G(H)=G$. This framework will be essential for interpreting the Sylow theorems.
+
+\newpage
+% ====================================================================
+\section{Simple Groups: The Atoms of Group Theory}
+% ====================================================================
+
+\begin{definition}[Simple Group]
+A group $G$ is called **simple** if its only normal subgroups are the trivial subgroup $\{e\}$ and the group $G$ itself.
+\end{definition}
+
+Simple groups are to finite group theory what prime numbers are to number theory. The Jordan-H\"older theorem states that any finite group can be broken down into a "composition series" of subgroups, where the successive quotients are simple groups. These simple groups are uniquely determined (up to isomorphism and reordering). In this sense, simple groups are the fundamental, indivisible "atoms" from which all finite groups are built.
+
+The classification of all finite simple groups was one of the monumental achievements of 20th-century mathematics, spanning thousands of pages of research. Our goal is much more modest: to use the Sylow theorems to prove that groups of certain orders are *not* simple.
+
+\begin{example}[Familiar Simple and Non-Simple Groups]
+\begin{itemize}
+    \item \textbf{Simple:} Any group $G$ of prime order $p$ is isomorphic to the cyclic group $C_p$. By Lagrange's theorem, its only subgroups are $\{e\}$ and $G$. Therefore, it is simple.
+    \item \textbf{Not Simple:} Any abelian group $G$ that is not of prime order is not simple. If $G$ is abelian, every subgroup is normal. If $|G|$ is not prime, it has a proper non-trivial subgroup (e.g., by Cauchy's theorem), which must be normal.
+    \item \textbf{Example:} A group of order $p^2$ (for a prime $p$) is always abelian. Therefore, it is not simple (unless its order is $2^1=2$, which is the prime case).
+    \item \textbf{Simple:} The alternating group $A_n$ is simple for all $n \ge 5$. This is a deep and important result. $A_5$, of order 60, is the smallest non-abelian simple group.
+\end{itemize}
+\end{example}
+
+Our main strategy for proving a group $G$ is not simple is to find a non-trivial proper normal subgroup $N$ (i.e., $\{e\} \neq N \neq G$). The Sylow theorems will be our primary tool for finding such a subgroup.
+
+\newpage
+% ====================================================================
+\section{The Sylow Theorems}
+% ====================================================================
+
+We have finally arrived. Here are the three theorems that form the bedrock of our analysis. Let $G$ be a finite group, and let $p$ be a prime. We can write the order of $G$ as $|G| = p^\alpha m$, where $p$ does not divide $m$. So, $p^\alpha$ is the highest power of $p$ that divides $|G|$.
+
+\begin{definition}[Sylow $p$-Subgroup]
+A subgroup of $G$ of order $p^\alpha$ is called a **Sylow $p$-subgroup** of $G$. The set of all Sylow $p$-subgroups of $G$ is denoted by $\Syl_p(G)$, and its size is denoted by $n_p(G)$ or just $n_p$.
+\end{definition}
+
+\begin{theorem}[Sylow I: Existence]
+For any prime $p$ dividing $|G|$, $G$ has at least one Sylow $p$-subgroup.
+\end{theorem}
+\begin{note}
+This is a powerful partial converse to Lagrange's Theorem. Lagrange says subgroup orders must divide the group order. Sylow I says that for prime powers, if $p^\alpha$ is the biggest power of $p$ dividing $|G|$, then a subgroup of that order is guaranteed to exist.
+\end{note}
+
+\begin{theorem}[Sylow II: Conjugacy and Containment]
+Let $P$ be a Sylow $p$-subgroup of $G$, and let $H$ be any $p$-subgroup of $G$ (i.e., $|H|=p^k$ for some $k \le \alpha$). Then:
+\begin{enumerate}
+    \item $H$ is contained in some conjugate of $P$. That is, there exists a $g \in G$ such that $H \subseteq gPg^{-1}$.
+    \item All Sylow $p$-subgroups are conjugate to one another. If $P_1$ and $P_2$ are two Sylow $p$-subgroups, then there exists a $g \in G$ such that $P_1 = gP_2g^{-1}$.
+\end{enumerate}
+\end{theorem}
+\begin{note}
+This tells us that all Sylow $p$-subgroups are "clones" of each other. They are all isomorphic and live in a single conjugacy class of subgroups. This means that to understand all of them, we only need to understand one of them. The number of them, $n_p$, is the size of this conjugacy class.
+\end{note}
+
+\begin{theorem}[Sylow III: Counting]
+Let $n_p$ be the number of Sylow $p$-subgroups of $G$. Then $n_p$ must satisfy two conditions:
+\begin{enumerate}
+    \item $n_p \equiv 1 \pmod{p}$
+    \item $n_p$ divides $m$ (the non-$p$ part of $|G|$).
+\end{enumerate}
+\end{theorem}
+\begin{note}
+This is the computational heart of the theory. It gives us incredibly strong restrictions on what $n_p$ can be. Often, these two conditions will force $n_p$ to be 1.
+\end{note}
+
+\subsection{The All-Important Consequence: When is a Sylow Subgroup Normal?}
+
+Let's combine what we know. Let $P$ be a Sylow $p$-subgroup.
+\begin{itemize}
+    \item We know $P$ is normal if and only if it is the *only* subgroup in its conjugacy class.
+    \item Sylow II says that *all* Sylow $p$-subgroups are in a single conjugacy class.
+\end{itemize}
+This means that $P$ is normal if and only if it is the *only* Sylow $p$-subgroup. In other words:
+
+\begin{corollary}[The Normality Test]
+A Sylow $p$-subgroup $P$ is normal in $G$ if and only if $n_p = 1$.
+\end{corollary}
+
+This is the jackpot. If our calculations from Sylow III show that $n_p$ must be 1, we have found a non-trivial proper normal subgroup (unless $G$ is a $p$-group itself), and we can immediately conclude that $G$ is not simple.
+
+\newpage
+% ====================================================================
+\section{The Sylow Strategy: A Step-by-Step Guide}
+% ====================================================================
+
+Here is a practical, step-by-step guide for using the Sylow theorems to analyze a group $G$ of a given order and, most commonly, to determine if it can be a simple group.
+
+\begin{strategy}[The Sylow Game Plan]
+Given a group $G$ with order $|G|=N$.
+
+\textbf{Step 1: Factor the Order}
+\begin{itemize}
+    \item Write the prime factorization of the order of the group: $|G| = p_1^{\alpha_1} p_2^{\alpha_2} \cdots p_k^{\alpha_k}$.
+    \item For each prime factor $p_i$, identify the components for the Sylow theorems: $p=p_i$, $\alpha=\alpha_i$, and $m = |G|/p_i^{\alpha_i}$.
+\end{itemize}
+
+\textbf{Step 2: List the Possibilities for $n_p$}
+\begin{itemize}
+    \item For each prime $p$ dividing $|G|$, use Sylow III.
+    \item First, use the divisibility condition: $n_p$ must be a divisor of $m$. List all divisors of $m$.
+    \item Second, use the congruence condition: $n_p \equiv 1 \pmod{p}$. Filter your list of divisors, keeping only those that satisfy this congruence.
+\end{itemize}
+
+\textbf{Step 3: Look for the Jackpot ($n_p=1$)}
+\begin{itemize}
+    \item Examine the lists of possibilities for each $n_p$. If for any prime $p$, the only possibility is $n_p=1$, you have found a unique, and therefore **normal**, Sylow $p$-subgroup.
+    \item If you find one, you can immediately conclude that \textbf{$G$ is not simple}. This is the most common and direct application.
+\end{itemize}
+
+\textbf{Step 4: If No Jackpot, Try Counting Elements}
+\begin{itemize}
+    \item This is an argument by contradiction. Assume $G$ is simple, which means $n_p > 1$ for all primes $p$.
+    \item Pick a prime $p$ where $n_p$ is large. Calculate the number of elements of order $p$ (or powers of $p$) contained in these Sylow $p$-subgroups.
+    \item A Sylow $p$-subgroup $P$ of order $p^\alpha$ has $p^\alpha-1$ non-identity elements. If the intersection of any two distinct Sylow $p$-subgroups is just $\{e\}$, then $n_p$ such subgroups would contribute $n_p(p^\alpha-1)$ elements of prime-power order.
+    \item Do this for another prime $q$. Add up the number of elements you've counted. If the total number of elements required is greater than $|G|$, you have a contradiction. Therefore, the assumption that $n_p > 1$ for all $p$ must be false.
+    \item This implies that for some $p$, $n_p=1$, so $G$ is not simple. (Or, in the element counting, that the intersection of Sylow subgroups must be larger than $\{e\}$, which can also be used).
+\end{itemize}
+
+\textbf{Step 5: If Counting Fails, Use an Action}
+\begin{itemize}
+    \item This is the most sophisticated technique. Assume $n_p > 1$ for some $p$.
+    \item Let $X = \Syl_p(G)$, the set of all Sylow $p$-subgroups. The size of this set is $|X|=n_p$.
+    \item The group $G$ acts on this set $X$ by conjugation: $g \cdot P = gPg^{-1}$.
+    \item This action induces a homomorphism $\phi: G \to S_X \cong S_{n_p}$.
+    \item The kernel of this homomorphism, $\Ker(\phi)$, is a normal subgroup of $G$.
+    \item \textbf{Case 1: The kernel is non-trivial.} If $\Ker(\phi)$ is not $\{e\}$ or $G$, then you have found a proper non-trivial normal subgroup, and $G$ is not simple.
+    \item \textbf{Case 2: The kernel is trivial.} If $\Ker(\phi)=\{e\}$, then $\phi$ is injective. By the First Isomorphism Theorem, $G \cong \phi(G)$, which is a subgroup of $S_{n_p}$. This implies that $|G|$ must divide $|S_{n_p}| = n_p!$.
+    \item Check if $|G|$ divides $n_p!$. In many cases, it won't, giving you a contradiction. This means the kernel could not have been trivial, so you must be in Case 1. Either way, $G$ is not simple.
+\end{itemize}
+\end{strategy}
+
+\begin{remark}[The Index-2 Rule]
+A very useful shortcut: any subgroup $H$ of index 2 in a finite group $G$ (i.e., $[G:H]=2$) is automatically normal. This is because there are only two left cosets ($H$ and $gH$ for $g \notin H$) and two right cosets ($H$ and $Hg$). The left cosets must be the same as the right cosets. This can sometimes be used in conjunction with Sylow arguments.
+\end{remark}
+
+\newpage
+% ====================================================================
+\section{Applications: The Sylow Theorems in Action}
+% ====================================================================
+
+Now for the fun part. Let's apply our strategy to groups of various orders to see what we can deduce about their structure.
+
+% --------------------------------------------------------------------
+\subsection{Case Study 1: Any group of order 15 is cyclic}
+% --------------------------------------------------------------------
+Let $G$ be a group with $|G|=15 = 3 \cdot 5$. We want to show $G$ is not only *not simple*, but is in fact isomorphic to $C_{15}$.
+
+\textbf{Step 1: Factorization.} $|G|=3^1 \cdot 5^1$. The primes are $p=3$ and $p=5$.
+
+\textbf{Step 2: Calculate $n_p$ possibilities.}
+\begin{itemize}
+    \item For $p=5$: $|G|=5^1 \cdot 3$. Here $\alpha=1, m=3$.
+        \begin{itemize}
+            \item $n_5$ must divide $m=3$. Divisors of 3 are $\{1, 3\}$.
+            \item $n_5 \equiv 1 \pmod{5}$. Let's check:
+                \begin{itemize}
+                    \item Is $1 \equiv 1 \pmod{5}$? Yes.
+                    \item Is $3 \equiv 1 \pmod{5}$? No.
+                \end{itemize}
+        \end{itemize}
+        The only possibility is $n_5=1$.
+
+    \item For $p=3$: $|G|=3^1 \cdot 5$. Here $\alpha=1, m=5$.
+        \begin{itemize}
+            \item $n_3$ must divide $m=5$. Divisors of 5 are $\{1, 5\}$.
+            \item $n_3 \equiv 1 \pmod{3}$. Let's check:
+                \begin{itemize}
+                    \item Is $1 \equiv 1 \pmod{3}$? Yes.
+                    \item Is $5 = 3(1)+2 \equiv 2 \pmod{3}$? No.
+                \end{itemize}
+        \end{itemize}
+        The only possibility is $n_3=1$.
+\end{itemize}
+
+\textbf{Step 3: The Jackpot!}
+We found that $n_5=1$ and $n_3=1$.
+\begin{itemize}
+    \item Since $n_5=1$, there is a unique Sylow 5-subgroup, let's call it $P_5$. It must be normal in $G$. $|P_5|=5$.
+    \item Since $n_3=1$, there is a unique Sylow 3-subgroup, let's call it $P_3$. It must be normal in $G$. $|P_3|=3$.
+\end{itemize}
+Since both Sylow subgroups are normal, we can investigate their product.
+\begin{itemize}
+    \item The intersection $P_3 \cap P_5$ is a subgroup of both $P_3$ and $P_5$. By Lagrange's theorem, its order must divide $|P_3|=3$ and $|P_5|=5$. The only common divisor is 1, so $|P_3 \cap P_5|=1$, which means $P_3 \cap P_5 = \{e\}$.
+    \item Both $P_3$ and $P_5$ are normal, so their product $P_3P_5$ is a subgroup of $G$. Its size is given by the product formula:
+    \[
+    |P_3P_5| = \frac{|P_3||P_5|}{|P_3 \cap P_5|} = \frac{3 \cdot 5}{1} = 15
+    \]
+    \item The subgroup $P_3P_5$ has the same order as $G$, so it must be that $G = P_3P_5$.
+\end{itemize}
+We have satisfied all the conditions for an internal direct product:
+\begin{enumerate}
+    \item $P_3 \unlhd G$ and $P_5 \unlhd G$.
+    \item $P_3 \cap P_5 = \{e\}$.
+    \item $G = P_3P_5$.
+\end{enumerate}
+Therefore, $G \cong P_3 \times P_5$.
+Since $P_3$ is a group of prime order 3, it must be cyclic: $P_3 \cong C_3$.
+Since $P_5$ is a group of prime order 5, it must be cyclic: $P_5 \cong C_5$.
+So, $G \cong C_3 \times C_5$. Since $\gcd(3,5)=1$, this direct product is isomorphic to the cyclic group of order 15: $G \cong C_{15}$.
+
+\textbf{Conclusion:} Any group of order 15 is cyclic.
+
+% --------------------------------------------------------------------
+\subsection{Case Study 2: Groups of order $pq$ ($p<q$ primes)}
+% --------------------------------------------------------------------
+This is a generalization of the previous case. Let $|G|=pq$ where $p, q$ are primes with $p<q$.
+
+\textbf{Step 1: Factorization.} $|G|=p^1 \cdot q^1$.
+
+\textbf{Step 2: Calculate $n_p$ possibilities.}
+\begin{itemize}
+    \item For the larger prime, $q$: $|G|=q^1 \cdot p$. So $m=p$.
+        \begin{itemize}
+            \item $n_q$ must divide $p$. Divisors of $p$ are $\{1, p\}$.
+            \item $n_q \equiv 1 \pmod{q}$.
+                \begin{itemize}
+                    \item $1 \equiv 1 \pmod{q}$ is always true.
+                    \item Can $p \equiv 1 \pmod{q}$? This would mean $p = kq+1$ for some integer $k \ge 1$. But we are given that $p < q$, so this is impossible.
+                \end{itemize}
+        \end{itemize}
+        The only possibility is $n_q=1$.
+
+    \item For the smaller prime, $p$: $|G|=p^1 \cdot q$. So $m=q$.
+        \begin{itemize}
+            \item $n_p$ must divide $q$. Divisors of $q$ are $\{1, q\}$.
+            \item $n_p \equiv 1 \pmod{p}$.
+                \begin{itemize}
+                    \item $1 \equiv 1 \pmod{p}$ is always true.
+                    \item $q \equiv 1 \pmod{p}$ is possible. For example, if $|G|=6=2 \cdot 3$, then $n_2$ could be 1 or 3, and $3 \equiv 1 \pmod{2}$.
+                \end{itemize}
+        \end{itemize}
+        So $n_p$ could be 1 or $q$.
+\end{itemize}
+
+\textbf{Step 3: Analysis.}
+We have a guaranteed jackpot for the larger prime: $n_q=1$. Let $Q$ be the unique Sylow $q$-subgroup. Then $Q \unlhd G$.
+Let $P$ be any Sylow $p$-subgroup. Since $Q$ is normal, the product $PQ$ is a subgroup of $G$.
+$|P \cap Q|$ must divide $|P|=p$ and $|Q|=q$, so $|P \cap Q|=1$.
+$|PQ| = |P||Q|/|P \cap Q| = pq/1 = |G|$. So $G=PQ$.
+Since $Q$ is normal, $G$ is a **semidirect product** of $Q$ by $P$, written $G \cong Q \rtimes P$.
+Since $P \cong C_p$ and $Q \cong C_q$, we have $G \cong C_q \rtimes C_p$.
+
+\textbf{Special Case: Cyclicity.}
+The semidirect product is a direct product (and thus $G$ is abelian and cyclic) if and only if the action of $P$ on $Q$ is trivial. This happens if $P$ is also normal, i.e., if $n_p=1$.
+When is $n_p=1$? This occurs if the other possibility, $n_p=q$, fails the congruence test.
+$n_p=1$ is the only option if $q \not\equiv 1 \pmod{p}$. This is equivalent to saying $p$ does not divide $q-1$.
+
+\textbf{Conclusion:}
+\begin{itemize}
+    \item A group of order $pq$ ($p<q$) always has a normal Sylow $q$-subgroup.
+    \item It is always a semidirect product $C_q \rtimes C_p$.
+    \item If $p$ does not divide $q-1$, then the group must be cyclic, $C_{pq}$. (e.g., $|G|=15=3 \cdot 5$, $3 \nmid (5-1)=4$).
+    \item If $p$ does divide $q-1$, a non-abelian group can exist. (e.g., $|G|=6=2 \cdot 3$, $2 \mid (3-1)=2$. We have $C_6$ and the non-abelian $S_3$).
+\end{itemize}
+
+% --------------------------------------------------------------------
+\subsection{Case Study 3: A group of order 45 is abelian}
+% --------------------------------------------------------------------
+Let $|G|=45 = 3^2 \cdot 5$.
+
+\textbf{Step 1: Factorization.} $|G|=3^2 \cdot 5^1$.
+
+\textbf{Step 2: Calculate $n_p$ possibilities.}
+\begin{itemize}
+    \item For $p=5$: $|G|=5^1 \cdot 9$. So $m=9$.
+        \begin{itemize}
+            \item $n_5$ must divide 9. Divisors are $\{1, 3, 9\}$.
+            \item $n_5 \equiv 1 \pmod{5}$.
+                \item $1 \equiv 1 \pmod{5}$ (Yes).
+                \item $3 \not\equiv 1 \pmod{5}$.
+                \item $9 \equiv 4 \pmod{5}$ (No).
+        \end{itemize}
+        The only possibility is $n_5=1$.
+
+    \item For $p=3$: $|G|=3^2 \cdot 5$. So $m=5$.
+        \begin{itemize}
+            \item $n_3$ must divide 5. Divisors are $\{1, 5\}$.
+            \item $n_3 \equiv 1 \pmod{3}$.
+                \item $1 \equiv 1 \pmod{3}$ (Yes).
+                \item $5 \equiv 2 \pmod{3}$ (No).
+        \end{itemize}
+        The only possibility is $n_3=1$.
+\end{itemize}
+
+\textbf{Step 3: Jackpot and Conclusion.}
+We have $n_5=1$ and $n_3=1$. Let $P_5$ be the unique Sylow 5-subgroup and $P_3$ be the unique Sylow 3-subgroup. Both are normal.
+As in the order 15 case, $P_3 \cap P_5 = \{e\}$ and $G = P_3P_5$.
+Thus, $G \cong P_3 \times P_5$.
+What do we know about $P_3$ and $P_5$?
+\begin{itemize}
+    \item $|P_5|=5$, so $P_5 \cong C_5$, which is abelian.
+    \item $|P_3|=3^2=9$. Any group of order $p^2$ is abelian. So $P_3$ is abelian (it's either $C_9$ or $C_3 \times C_3$).
+\end{itemize}
+Since $G$ is the direct product of two abelian groups, $G$ itself must be abelian.
+
+\textbf{Conclusion:} Any group of order 45 is abelian.
+
+\newpage
+% --------------------------------------------------------------------
+\subsection{Case Study 4: No simple group of order 56}
+% --------------------------------------------------------------------
+Let $|G|=56 = 8 \cdot 7 = 2^3 \cdot 7$. We will show $G$ cannot be simple.
+
+\textbf{Step 1: Factorization.} $|G|=2^3 \cdot 7^1$.
+
+\textbf{Step 2: Calculate $n_p$ possibilities.}
+\begin{itemize}
+    \item For $p=7$: $|G|=7^1 \cdot 8$. So $m=8$.
+        \begin{itemize}
+            \item $n_7$ must divide 8. Divisors are $\{1, 2, 4, 8\}$.
+            \item $n_7 \equiv 1 \pmod{7}$.
+                \item $1 \equiv 1 \pmod{7}$ (Yes).
+                \item $2 \not\equiv 1 \pmod{7}$.
+                \item $4 \not\equiv 1 \pmod{7}$.
+                \item $8 \equiv 1 \pmod{7}$ (Yes).
+        \end{itemize}
+        The possibilities are $n_7 \in \{1, 8\}$.
+
+    \item For $p=2$: $|G|=2^3 \cdot 7$. So $m=7$.
+        \begin{itemize}
+            \item $n_2$ must divide 7. Divisors are $\{1, 7\}$.
+            \item $n_2 \equiv 1 \pmod{2}$.
+                \item $1 \equiv 1 \pmod{2}$ (Yes).
+                \item $7 \equiv 1 \pmod{2}$ (Yes).
+        \end{itemize}
+        The possibilities are $n_2 \in \{1, 7\}$.
+\end{itemize}
+
+\textbf{Step 3: Analysis.}
+We don't have an immediate jackpot. If $n_7=1$ or $n_2=1$, we're done (the group is not simple).
+So, for the sake of contradiction, let's assume $G$ is simple. This means $n_p$ cannot be 1.
+Our possibilities become:
+\begin{itemize}
+    \item $n_7 = 8$
+    \item $n_2 = 7$
+\end{itemize}
+
+\textbf{Step 4: Count the Elements.}
+Let's see how many elements this assumption requires.
+\begin{itemize}
+    \item \textbf{Elements from Sylow 7-subgroups:}
+    We have $n_7=8$ Sylow 7-subgroups. Each is of prime order 7, so they are cyclic. The intersection of any two distinct Sylow 7-subgroups must be $\{e\}$ (since any non-identity element would generate the whole subgroup).
+    Each Sylow 7-subgroup contains $7-1=6$ elements of order 7.
+    Total elements of order 7 = (number of subgroups) $\times$ (elements of order 7 per subgroup)
+    Total = $8 \times 6 = 48$ elements.
+
+    \item \textbf{Elements from Sylow 2-subgroups:}
+    We have $n_2=7$ Sylow 2-subgroups. Each has order $2^3=8$.
+    Each of these contains the identity element plus 7 other elements of order 2, 4, or 8.
+
+    \item \textbf{The Contradiction:}
+    Let's sum up what we have so far.
+    We have 48 distinct elements of order 7.
+    This leaves $56 - 48 = 8$ elements remaining in the group.
+    These 8 remaining elements must include the identity element and all the elements that make up the Sylow 2-subgroups.
+    A single Sylow 2-subgroup has order 8. So, all 8 of these remaining elements must form *one single* Sylow 2-subgroup.
+    This implies there can only be one Sylow 2-subgroup, so $n_2=1$.
+    But this contradicts our assumption that $n_2=7$.
+\end{itemize}
+Our initial assumption (that $G$ is simple, forcing $n_7=8$ and $n_2=7$) has led to a logical impossibility. Therefore, the assumption must be false. At least one of $n_7$ or $n_2$ must be 1.
+
+\textbf{Conclusion:} A group of order 56 must have a normal Sylow subgroup (either for $p=7$ or $p=2$), and therefore cannot be simple.
+
+% --------------------------------------------------------------------
+\subsection{Case Study 5: No simple group of order 36}
+% --------------------------------------------------------------------
+Let $|G|=36 = 4 \cdot 9 = 2^2 \cdot 3^2$.
+
+\textbf{Step 1: Factorization.} $|G|=2^2 \cdot 3^2$.
+
+\textbf{Step 2: Calculate $n_p$ possibilities.}
+\begin{itemize}
+    \item For $p=3$: $|G|=3^2 \cdot 4$. So $m=4$.
+        \begin{itemize}
+            \item $n_3$ must divide 4. Divisors are $\{1, 2, 4\}$.
+            \item $n_3 \equiv 1 \pmod{3}$.
+                \item $1 \equiv 1 \pmod{3}$ (Yes).
+                \item $2 \not\equiv 1 \pmod{3}$.
+                \item $4 \equiv 1 \pmod{3}$ (Yes).
+        \end{itemize}
+        The possibilities are $n_3 \in \{1, 4\}$.
+
+    \item For $p=2$: $|G|=2^2 \cdot 9$. So $m=9$.
+        \begin{itemize}
+            \item $n_2$ must divide 9. Divisors are $\{1, 3, 9\}$.
+            \item $n_2 \equiv 1 \pmod{2}$. All are odd, so all are $\equiv 1 \pmod 2$.
+        \end{itemize}
+        The possibilities are $n_2 \in \{1, 3, 9\}$.
+\end{itemize}
+
+\textbf{Step 3: Analysis.}
+No immediate jackpot. Assume $G$ is simple, so $n_3=4$ and $n_2 \in \{3,9\}$.
+
+\textbf{Step 5: Use an Action.} (Element counting is also possible but this is a good demonstration of the action method).
+Let's focus on the Sylow 3-subgroups. Assume $n_3=4$.
+Let $X = \Syl_3(G)$, so $|X|=4$.
+$G$ acts on $X$ by conjugation. This gives a homomorphism $\phi: G \to S_X \cong S_4$.
+The kernel of $\phi$ is a normal subgroup of $G$. Since we are assuming $G$ is simple, the only possibilities for $\Ker(\phi)$ are $\{e\}$ or $G$.
+\begin{itemize}
+    \item Can $\Ker(\phi) = G$? The kernel is the set of elements that fix every Sylow 3-subgroup. If the kernel were $G$, it would mean $gPg^{-1}=P$ for all $g \in G$ and for any $P \in X$. This would mean all Sylow 3-subgroups are normal. But if they are all normal, they must all be the same subgroup, which would mean $n_3=1$. This contradicts our assumption that $n_3=4$. So $\Ker(\phi) \neq G$.
+    \item Therefore, if $G$ is simple, we must have $\Ker(\phi) = \{e\}$.
+\end{itemize}
+If the kernel is trivial, then $\phi$ is an injective map. This implies $G$ is isomorphic to a subgroup of $S_4$.
+This means $|G|$ must divide $|S_4|$.
+We have $|G|=36$ and $|S_4|=24$.
+Does 36 divide 24? No.
+This is a contradiction. Our assumption that $G$ is simple (which forced $n_3=4$ and a trivial kernel) must be false.
+
+The only way to resolve the contradiction is to accept that our assumption was wrong. The kernel cannot be trivial. So $\Ker(\phi)$ must be a proper non-trivial normal subgroup of $G$.
+
+\textbf{Conclusion:} Any group of order 36 is not simple.
+
+% --------------------------------------------------------------------
+\subsection{Case Study 6: No simple group of order 96}
+% --------------------------------------------------------------------
+Let $|G|=96 = 32 \cdot 3 = 2^5 \cdot 3$.
+
+\textbf{Step 1: Factorization.} $|G|=2^5 \cdot 3^1$.
+
+\textbf{Step 2: Calculate $n_p$ possibilities.}
+\begin{itemize}
+    \item For $p=3$: $|G|=3^1 \cdot 32$. So $m=32$.
+        \begin{itemize}
+            \item $n_3$ must divide 32. Divisors are $\{1, 2, 4, 8, 16, 32\}$.
+            \item $n_3 \equiv 1 \pmod{3}$.
+                \item $1 \equiv 1$ (Yes).
+                \item $2 \equiv 2$ (No).
+                \item $4 \equiv 1$ (Yes).
+                \item $8 \equiv 2$ (No).
+                \item $16 = 15+1 \equiv 1$ (Yes).
+                \item $32 = 30+2 \equiv 2$ (No).
+        \end{itemize}
+        The possibilities are $n_3 \in \{1, 4, 16\}$.
+\end{itemize}
+If $n_3=1$, we're done. Assume $G$ is simple, so $n_3 \in \{4, 16\}$.
+
+\textbf{Step 3: Analysis.}
+Let's consider the case $n_3=4$. This is exactly the same argument as for $|G|=36$.
+The action of $G$ on the 4 Sylow 3-subgroups gives a homomorphism $\phi: G \to S_4$.
+If $G$ is simple, the kernel must be trivial, implying $|G|$ divides $|S_4|$.
+$|G|=96$ and $|S_4|=24$. 96 does not divide 24. Contradiction.
+So if $n_3=4$, the group cannot be simple.
+
+What if $n_3=16$? Let's try element counting.
+If $n_3=16$, we have 16 Sylow 3-subgroups, each of order 3.
+Number of elements of order 3 = $16 \times (3-1) = 32$.
+This leaves $96-32 = 64$ elements for everything else.
+The Sylow 2-subgroups have order $2^5=32$.
+There are $n_2$ of them, where $n_2$ divides 3 and is $\equiv 1 \pmod 2$. So $n_2 \in \{1, 3\}$.
+If $n_2=1$, we're done.
+If $n_2=3$, we have 3 subgroups of order 32.
+The 64 remaining elements must contain these 3 subgroups of order 32.
+$|P_1 \cup P_2 \cup P_3|$ where $P_i$ are the Sylow 2-subgroups.
+$|P_1 \cup P_2| = |P_1|+|P_2|-|P_1 \cap P_2| = 32+32-|P_1 \cap P_2| = 64 - |P_1 \cap P_2|$.
+The intersection $P_1 \cap P_2$ must be a subgroup of a group of order 32, so its order is a power of 2. By a known theorem, the intersection of two Sylow subgroups can't have index $p$ in the Sylow subgroup, so $|P_1 \cap P_2| \le 16$.
+If $|P_1 \cap P_2|=16$, then $|P_1 \cup P_2| = 64-16=48$.
+This seems plausible. The counting argument is not as clear-cut here.
+
+However, the action argument on $\Syl_3(G)$ when $n_3=16$ also works.
+Action on $X=\Syl_3(G)$ gives $\phi: G \to S_{16}$.
+If the kernel is trivial, $|G|=96$ must divide $|S_{16}|=16!$. This is true, so it doesn't give a contradiction.
+But we can be more clever. Let $P$ be a Sylow 3-subgroup. The normalizer $N_G(P)$ has index $n_3=16$.
+$|N_G(P)| = |G|/n_3 = 96/16 = 6$.
+The kernel of the action is a subgroup of $N_G(P)$. So $|\Ker(\phi)|$ divides 6.
+If $G$ is simple, $\Ker(\phi)=\{e\}$. This is possible.
+This path is tricky. Let's go back to the $n_3=4$ case.
+
+The argument for $n_3=4$ was conclusive. So we just need to show $n_3=16$ is impossible.
+Suppose $n_3=16$. As calculated, $|N_G(P)|=6$ for a Sylow 3-subgroup $P$.
+Let $P = \{e, x, x^2\}$. $P$ is a normal subgroup of $N_G(P)$ (since it's a Sylow 3-subgroup of a group of order 6).
+The centralizer $C_G(P)$ is a subgroup of $N_G(P)$.
+$P \subseteq C_G(P) \subseteq N_G(P)$.
+So $|C_G(P)|$ can be 3 or 6.
+If $|C_G(P)|=6$, then $N_G(P)$ is abelian, so $N_G(P) \cong C_6$.
+If $|C_G(P)|=3$, then $N_G(P)/C_G(P)$ embeds into $\Aut(P) \cong \Aut(C_3) \cong C_2$. This is consistent with $|N_G(P)/C_G(P)|=6/3=2$. So $N_G(P) \cong S_3$.
+This doesn't seem to lead to a contradiction easily.
+
+Let's reconsider the whole problem. We have $n_3 \in \{1, 4, 16\}$.
+If $n_3=1$, $G$ is not simple.
+If $n_3=4$, we get a homomorphism $\phi: G \to S_4$. $|G|=96$, $|S_4|=24$. $\Ker(\phi)$ cannot be trivial. Is it possible $\Ker(\phi)=G$? No, that would imply $n_3=1$. So if $n_3=4$, $G$ is not simple.
+This means a simple group of order 96 must have $n_3=16$.
+And it must have $n_2=3$.
+Let's try the element counting again, more carefully.
+Number of elements of order 3 or 6 (in the normalizers) is complex.
+Let's just stick to the simplest path. The possibility of $n_3=4$ leads to non-simplicity. So we only need to worry if $n_3$ is *forced* to be 16. But it isn't. A group of order 96 could have $n_3=4$. And if it does, it's not simple. What if a group of order 96 *must* have $n_3 \neq 4$? We don't know this. The problem is just to show *any* group of order 96 is not simple. The fact that the case $n_3=4$ forces non-simplicity is enough. One of the possibilities for $n_3$ leads to non-simplicity. Does this mean the group is not simple? Yes. The group has a certain value for $n_3$. That value is either 1, 4, or 16. If it's 1, not simple. If it's 4, not simple. If it's 16... maybe it is, maybe it isn't. But we can't assume which value it takes.
+
+Let's refine the argument. Let $G$ be a group of order 96. Let $P$ be a Sylow 2-subgroup, $|P|=32$. Let $H$ be the intersection of all Sylow 2-subgroups. $H$ is normal. If $H$ is non-trivial, $G$ is not simple.
+Consider the case where the intersection of all Sylow 2-subgroups is trivial.
+This is getting too complicated. The simplest argument is the best.
+
+Let's assume $G$ is a simple group of order 96.
+Then $n_3 \neq 1$. So $n_3 \in \{4, 16\}$.
+If $n_3=4$, we showed this leads to a contradiction unless $G$ is not simple. So a simple group of order 96 must have $n_3=16$.
+Also, $n_2 \neq 1$, so $n_2=3$.
+Let $P$ be a Sylow 2-subgroup of order 32.
+Let $G$ act on the set of left cosets of $P$, $X = G/P$. $|X|=[G:P]=3$.
+This gives a homomorphism $\phi: G \to S_3$.
+The kernel is a normal subgroup. If $G$ is simple, kernel must be $\{e\}$ or $G$.
+Kernel can't be $G$. So $\Ker(\phi)=\{e\}$.
+This means $G$ is isomorphic to a subgroup of $S_3$.
+$|G|=96$, $|S_3|=6$. This is a contradiction.
+The kernel must be non-trivial.
+So there is a normal subgroup $\Ker(\phi)$. Is it proper? Yes, because the action is transitive, so the kernel is not $G$.
+So we have found a proper non-trivial normal subgroup.
+
+\textbf{Conclusion:} Any group of order 96 is not simple. The argument using the index of the Sylow 2-subgroup is the most direct.
+
+\newpage
+% ====================================================================
+\section{Exercises and Further Problems}
+% ====================================================================
+
+Use the strategies and examples from the previous sections to solve these problems.
+
+\begin{enumerate}
+  \item \textbf{Order 65:} Show that any group of order $65=5 \cdot 13$ is cyclic.
+  \begin{itemize}
+    \item \textit{Hint:} Calculate $n_{13}$ and $n_5$. Show they must both be 1. Then show the group is a direct product of its Sylow subgroups.
+  \end{itemize}
+
+  \item \textbf{Order 255:} Show that any group of order $255 = 3 \cdot 5 \cdot 17$ is cyclic.
+  \begin{itemize}
+    \item \textit{Hint:} Show $n_{17}=1$. Let $P_{17}$ be this normal subgroup. Consider the quotient group $G/P_{17}$ of order 15. We know any group of order 15 is cyclic. Use this and properties of homomorphisms to deduce facts about $G$. Alternatively, show $n_5=1$ and $n_3=1$ as well.
+  \end{itemize}
+
+  \item \textbf{Order 28:} Show that a group of order $28=2^2 \cdot 7$ must have a normal Sylow 7-subgroup and is not simple. Classify all groups of order 28 up to isomorphism (there are two, one abelian and one non-abelian).
+
+  \item \textbf{Order 30:} Show that any group of order $30=2 \cdot 3 \cdot 5$ has a normal subgroup of order 15.
+  \begin{itemize}
+    \item \textit{Hint:} Show that either $n_3=1$ or $n_5=1$. Let $P_3$ be a Sylow 3-subgroup and $P_5$ a Sylow 5-subgroup. If $P_5$ is normal, consider the product $P_3P_5$. Show it is a subgroup of order 15. What if $P_3$ is normal? What if both are not normal? Count elements.
+  \end{itemize}
+  
+  \item \textbf{Index $p$ Subgroup:} Let $G$ be a finite group and let $p$ be the smallest prime dividing $|G|$. Show that any subgroup of index $p$ is normal.
+  \begin{itemize}
+    \item \textit{Hint:} Let $H$ be a subgroup with $[G:H]=p$. Let $G$ act on the set of left cosets of $H$. This gives a homomorphism $\phi: G \to S_p$. Consider the kernel. What can you say about its order?
+  \end{itemize}
+
+\end{enumerate}
+
+\newpage
+% ====================================================================
+\section*{Summary: The Sylow Pocket Checklist}
+% ====================================================================
+
+When faced with a finite group problem, especially one about simplicity or structure, keep this checklist in your pocket.
+
+\begin{itemize}[label=\tick]
+  \item \textbf{Factor the Order:} $|G| = p^\alpha m$. This is always the first step. It sets up everything else.
+
+  \item \textbf{The Two Conditions:} For each prime $p$, remember the two magic constraints on $n_p$:
+    \begin{enumerate}
+        \item $n_p$ must divide $m$.
+        \item $n_p$ must be congruent to $1 \pmod p$.
+    \end{enumerate}
+
+  \item \textbf{The $n_p=1$ Jackpot:} If your calculations force $n_p=1$ for any prime $p$, you've struck gold. You have found a unique, and therefore normal, Sylow $p$-subgroup. The group is not simple.
+
+  \item \textbf{Contradiction by Counting:} If you assume the group is simple (so all $n_p > 1$), you can often show that the number of elements required to populate all these different Sylow subgroups exceeds the total number of elements in the group. This is a powerful contradiction argument.
+
+  \item \textbf{Contradiction by Action:} The most powerful tool. If other methods fail, have the group $G$ act on something.
+    \begin{itemize}
+        \item \textbf{Action on Sylow Subgroups:} Let $G$ act on $X=\Syl_p(G)$. This gives $\phi: G \to S_{n_p}$. If $G$ is simple, the kernel must be trivial, so $|G|$ must divide $n_p!$. This often fails.
+        \item \textbf{Action on Cosets:} Let $G$ act on the cosets of a large subgroup $H$ (often a Sylow subgroup or a normalizer). This gives $\phi: G \to S_{[G:H]}$. Again, if $G$ is simple, $|G|$ must divide $[G:H]!$. This is an even stronger restriction.
+    \end{itemize}
+
+  \item \textbf{Deconstruction with Products:} If you find normal subgroups $H$ and $K$, remember the product rules. If they are Sylow subgroups for different primes, their intersection is trivial. If they are both normal, you can form a direct product $H \times K$. This tells you the group is built from smaller, simpler pieces.
+\end{itemize}
+
+The Sylow theorems are a beautiful example of how simple arithmetic constraints can reveal deep structural truths about abstract objects. Master this checklist, and you'll have a powerful lens through which to view the finite group universe. Good luck!
+
+\end{document}
+% ====================================================================
+%                          DOCUMENT END
+% ====================================================================

--- a/sylow.tex
+++ b/sylow.tex
@@ -68,6 +68,12 @@
   {\Large A comprehensive, example-driven journey into the heart of finite group theory}
 \end{center}
 
+\begin{center}
+\fbox{\begin{minipage}{0.9\textwidth}
+\textbf{Warning.} These notes were created with the assistance of artificial intelligence and may contain errors. Read with caution, and send any corrections or suggestions to \href{mailto:jayakumarrct@gmail.com}{jayakumarrct@gmail.com}. Positive criticism is always welcome.
+\end{minipage}}
+\end{center}
+
 \section*{To the Student: Your Compass in the World of Finite Groups}
 
 Welcome! You're about to explore one of the most powerful and elegant set of tools in abstract algebra: the **Sylow Theorems**. Imagine you're an explorer given a map of a vast, unknown territory—the world of finite groups. This territory is populated by groups of every conceivable size. Your map is incomplete, but you have a special compass. This compass doesn't point north; instead, it points to special subgroups, the **Sylow $p$-subgroups**.


### PR DESCRIPTION
## Summary
- add comprehensive Sylow Theorems LaTeX document for finite group theory notes

## Testing
- `pdflatex -interaction=nonstopmode sylow.tex` *(fails: File `enumitem.sty` not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c3e426e84833190bca0dcf2d03667