### PR TITLE
Add LaTeX section stubs for Galois theory

### DIFF
--- a/00_outline.tex
+++ b/00_outline.tex
@@ -1,0 +1,1 @@
+\section{Study Outline}\label{sec:outline}

--- a/01_fields.tex
+++ b/01_fields.tex
@@ -1,0 +1,1 @@
+\section{Fields and Extensions}\label{sec:fields}

--- a/02_irreducibility.tex
+++ b/02_irreducibility.tex
@@ -1,0 +1,1 @@
+\section{Irreducibility Tools}\label{sec:irreducibility}

--- a/03_splitting.tex
+++ b/03_splitting.tex
@@ -1,0 +1,1 @@
+\section{Splitting Fields and Closures}\label{sec:splitting}

--- a/04_separable.tex
+++ b/04_separable.tex
@@ -1,0 +1,1 @@
+\section{Separable vs Inseparable}\label{sec:separable}

--- a/05_automorphisms.tex
+++ b/05_automorphisms.tex
@@ -1,0 +1,1 @@
+\section{Automorphisms and Fixed Fields}\label{sec:automorphisms}

--- a/06_galois_extensions.tex
+++ b/06_galois_extensions.tex
@@ -1,0 +1,1 @@
+\section{Galois Extensions}\label{sec:galois-extensions}

--- a/07_fundamental_theorem.tex
+++ b/07_fundamental_theorem.tex
@@ -1,0 +1,1 @@
+\section{Fundamental Theorem of Galois Theory}\label{sec:FTGT}

--- a/08_galois_groups_poly.tex
+++ b/08_galois_groups_poly.tex
@@ -1,0 +1,1 @@
+\section{Galois Groups of Polynomials}\label{sec:galois-groups-poly}

--- a/09_solvability.tex
+++ b/09_solvability.tex
@@ -1,0 +1,1 @@
+\section{Solvability by Radicals}\label{sec:solvability}

--- a/10_cyclotomic_kummer.tex
+++ b/10_cyclotomic_kummer.tex
@@ -1,0 +1,1 @@
+\section{Cyclotomic and Kummer Theory}\label{sec:cyclotomic-kummer}

--- a/11_finite_fields.tex
+++ b/11_finite_fields.tex
@@ -1,0 +1,1 @@
+\section{Finite Fields}\label{sec:finite-fields}

--- a/12_infinite_galois.tex
+++ b/12_infinite_galois.tex
@@ -1,0 +1,1 @@
+\section{Infinite Galois Theory}\label{sec:infinite-galois}

--- a/13_ramification.tex
+++ b/13_ramification.tex
@@ -1,0 +1,1 @@
+\section{Primes, Decomposition, and Ramification}\label{sec:ramification}

--- a/14_artin_schreier.tex
+++ b/14_artin_schreier.tex
@@ -1,0 +1,1 @@
+\section{Artin--Schreier and Inseparable Phenomena}\label{sec:artin-schreier}

--- a/15_computation.tex
+++ b/15_computation.tex
@@ -1,0 +1,1 @@
+\section{Computational Galois Theory}\label{sec:computation}

--- a/99_figures.tex
+++ b/99_figures.tex
@@ -1,0 +1,1 @@
+\section{Figure Bank}\label{sec:figures}


### PR DESCRIPTION
## Summary
- add chapter stub files for study outline, fields, extensions, and more

## Testing
- `pdflatex 00_outline.tex` *(fails: Missing character in nullfont as expected for snippet)*

------
https://chatgpt.com/codex/tasks/task_e_689d5b7ad34c83318668837609f676e2