### PR TITLE
Fix xcolor option clash and undefined colors

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1,9 +1,9 @@
 \documentclass[12pt]{article}
 
 \usepackage{amsmath,amssymb}
+\usepackage[dvipsnames,svgnames]{xcolor}
 \usepackage{tikz}
 \usepackage{tikz-cd}
-\usepackage[dvipsnames]{xcolor}
 \usepackage{graphicx}
 \usepackage{mwe}
 \usepackage{hyperref}


### PR DESCRIPTION
## Summary
- Load xcolor before TikZ to avoid option clashes
- Enable SVG color names such as teal by adding `svgnames` option

## Testing
- `make` *(fails: latexmk not found)*
- `apt-get update` *(fails: repository not signed / 403)*
- `apt-get install -y latexmk` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a00d0cc1348331bfb3af2b03d33bc9