### PR TITLE
Fix xcolor option clash and custom enumerate labels

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1,13 +1,14 @@
 \documentclass[12pt]{article}
 
 \usepackage{amsmath,amssymb}
+\usepackage[dvipsnames,svgnames]{xcolor}
 \usepackage{tikz}
 \usepackage{tikz-cd}
-\usepackage[dvipsnames]{xcolor}
 \usepackage{graphicx}
 \usepackage{mwe}
 \usepackage{hyperref}
 \usepackage{cleveref}
+\usepackage{enumitem}
 % ---------- Fonts and colors ----------
 \usepackage{mathpazo} % Palatino text & math
 \usepackage[scaled=0.85]{inconsolata} % Monospace font


### PR DESCRIPTION
## Summary
- Load xcolor before TikZ and enable SVG color names
- Load enumitem to support custom enumerate labels

## Testing
- `make` *(fails: latexmk: No such file or directory)*
- `apt-get update && apt-get install -y latexmk` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a00d0cc1348331bfb3af2b03d33bc9