### PR TITLE
lesson-proofs-sec3-6

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ latexmk -pdf -interaction=nonstopmode -shell-escape main.tex
 ```
 
 ## Proof Style
-Proofs use the plain `amsthm` environment with simple English and only the steps needed. When a proof ends with a displayed equation we place the symbol using `\qedhere`. Sections&nbsp;1–2 now follow this style.
+Proofs use the plain `amsthm` environment with simple English and only the steps needed. When a proof ends with a displayed equation we place the symbol using `\qedhere`. Sections&nbsp;1–6 now follow this style.
 
 ## Worked Examples
 Example files live under `examples/section-*-examples.tex`. Add more by following the same format and labeling examples as `ex:sec<i>-<k>`. Compile the notes with:

--- a/sections/sec03-splitting-algebraic-closure.tex
+++ b/sections/sec03-splitting-algebraic-closure.tex
@@ -7,8 +7,17 @@ A \emph{splitting field} of $f\in F[x]$ is a minimal extension $E/F$ over which 
 \begin{theorem}[Existence and uniqueness]
 Every $f\in F[x]$ has a splitting field $E/F$, unique up to $F$-isomorphism.
 \end{theorem}
-\begin{proof}[Idea]
-Existence by adjoining roots one by one; uniqueness by extending embeddings and induction on $\deg f$.
+\begin{proof}
+Pick a root $\alpha$ of $f$ in some extension of $F$ and let $F_1=F(\alpha)$. Then
+\(f=(x-\alpha)g\) with $g\in F_1[x]$ of smaller degree, so by induction on the
+degree we obtain a field $E$ over which $g$ splits. This $E$ is generated over
+$F$ by adjoining all the roots of $f$, hence it is a splitting field.
+
+For uniqueness, let $E$ and $E'$ be splitting fields of $f$. Choose a root
+$\alpha\in E$ and a corresponding root $\beta\in E'$ of its minimal polynomial
+over $F$. The map $\alpha\mapsto\beta$ extends to an $F$-isomorphism
+$F(\alpha)\cong F(\beta)$. Applying the inductive construction to the remaining
+factors of $f$ extends this to an $F$-isomorphism $E\cong E'$.
 \end{proof}
 References: \cite[\S14]{DF}, \cite[Ch.~V]{Artin}.
 
@@ -19,6 +28,18 @@ An \emph{algebraic closure} $\overline{F}$ of $F$ is an algebraic extension that
 \begin{theorem}
 Every $F$ has an algebraic closure, unique up to $F$-isomorphism.
 \end{theorem}
+\begin{proof}
+Consider the set of algebraic extensions of $F$ ordered by inclusion in which
+each polynomial of $F[x]$ has at least one root. Any chain has an upper bound by
+the union of its fields, so Zorn's lemma yields a maximal such extension
+$\overline{F}$. If a polynomial in $\overline{F}[x]$ were irreducible with no
+root in $\overline{F}$, adjoining a root would contradict maximality, hence
+$\overline{F}$ is algebraically closed and algebraic over $F$.
+
+If $\overline{F}'$ is another algebraic closure, the previous theorem gives an
+$F$-isomorphism between their splitting fields for each polynomial in $F[x]$,
+which patch together to an $F$-isomorphism $\overline{F}\cong\overline{F}'$.
+\end{proof}
 \begin{remark}
 Construction uses Zorn's lemma; see \cite[Ch.~VIII]{Lang}.
 \end{remark}
@@ -27,6 +48,15 @@ Construction uses Zorn's lemma; see \cite[Ch.~VIII]{Lang}.
 \begin{proposition}
 Let $E/F$ be finite and $\sigma:E\hookrightarrow \overline{F}$ an $F$-embedding. Then $\#\{\sigma\}\le [E\!:\!F]$, with equality iff $E/F$ is separable.
 \end{proposition}
+\begin{proof}
+Write $E=F(\alpha_1,\ldots,\alpha_n)$ and set $E_i=F(\alpha_1,\ldots,\alpha_i)$.
+An $F$-embedding of $E_{i-1}$ extends to at most $d_i$ embeddings of $E_i$,
+where $d_i$ is the number of distinct roots of the minimal polynomial of
+$\alpha_i$ over $E_{i-1}$. Thus the number of $F$-embeddings of $E$ is at most
+$d_1\cdots d_n=[E\!:\!F]$. Equality holds precisely when each $d_i$ equals the
+degree of the corresponding minimal polynomial, which is the definition of
+separability for $E/F$.
+\end{proof}
 
 \subsection{Examples}
 \begin{example}

--- a/sections/sec04-automorphisms-fixedfields.tex
+++ b/sections/sec04-automorphisms-fixedfields.tex
@@ -20,6 +20,15 @@ If $f(\alpha)=0$, then $0=\sigma(f(\alpha))=f(\sigma(\alpha))$ because $\sigma$ 
 \begin{theorem}\label{thm:autobound}
 For any finite extension $E/F$, $\#\Aut_F(E)\le [E\!:\!F]$, with equality iff $E/F$ is Galois; see \cref{sec:galois-ft}.
 \end{theorem}
+\begin{proof}
+Every $F$-automorphism of $E$ is an $F$-embedding $E\hookrightarrow\overline{F}$,
+so the bound follows from \cref{sec:splitting-fields}'s proposition on
+embeddings. If equality holds then $E/F$ is separable by that result, and the
+images of elements under these embeddings lie in $E$, forcing every irreducible
+polynomial with a root in $E$ to split over $E$; thus $E/F$ is normal and hence
+Galois. Conversely, if $E/F$ is Galois, any $F$-embedding of $E$ lands in $E$ and
+is an automorphism, giving $\#\Aut_F(E)=[E\!:\!F]$.
+\end{proof}
 References: \cite[\S14]{DF}, \cite[Ch.~V]{Artin}.
 
 \subsection{Examples}

--- a/sections/sec05-separable-normal.tex
+++ b/sections/sec05-separable-normal.tex
@@ -7,6 +7,13 @@ For $f(x)=\sum a_i x^i\in F[x]$, the \emph{formal derivative} is $f'(x)=\sum i\,
 \begin{proposition}[Multiplicity]
 In a splitting field, a root $\alpha$ has multiplicity $>1$ iff $f(\alpha)=f'(\alpha)=0$.
 \end{proposition}
+\begin{proof}
+Write $f=(x-\alpha)^m g$ in the splitting field with $g(\alpha)\ne0$. Then
+\(f' = m(x-\alpha)^{m-1} g + (x-\alpha)^m g'\). If $m>1$ both $f(\alpha)$ and
+$f'(\alpha)$ vanish. Conversely, if $f(\alpha)=f'(\alpha)=0$ and $f=(x-\alpha)g$
+with $g(\alpha)\ne0$, then $f'(\alpha)=g(\alpha)\ne0$, a contradiction; hence
+$m>1$.
+\end{proof}
 \begin{theorem}[Separability criteria]\label{thm:sep-criteria}
 For irreducible $f\in F[x]$ the following are equivalent:
 \begin{enumerate}[label=(\alph*)]
@@ -16,9 +23,25 @@ For irreducible $f\in F[x]$ the following are equivalent:
 \end{enumerate}
 A root of such $f$ is \emph{separable}. An algebraic extension is \emph{separable} if each of its elements is separable.
 \end{theorem}
+\begin{proof}
+(a)$\Leftrightarrow$(b): a multiple root $\alpha$ of $f$ satisfies
+$f(\alpha)=f'(\alpha)=0$, so $\gcd(f,f')$ has positive degree. Conversely, if
+$\gcd(f,f')\ne1$, a common root gives a multiple root.
+
+(a)$\Leftrightarrow$(c): In a splitting field the embeddings of $F[x]/(f)$ send
+$x$ to the distinct roots of $f$. Thus the number of embeddings equals the number
+of distinct roots, which is $\deg f$ precisely when $f$ has no multiple roots.
+\end{proof}
 \begin{corollary}[Perfect fields]
 If $\operatorname{char}F=0$ or $F$ is finite then every algebraic extension of $F$ is separable.
 \end{corollary}
+\begin{proof}
+Let $f\in F[x]$ be irreducible. If $\operatorname{char}F=0$ then $f'\ne0$.
+When $F$ is finite of characteristic $p$, the Frobenius map $x\mapsto x^p$ is
+bijective, so an irreducible $f$ cannot be of the form $g(x^p)$ and hence
+$f'\ne0$. By \cref{thm:sep-criteria}, $f$ is separable, and thus every algebraic
+extension of $F$ is separable.
+\end{proof}
 References: \cite[\S13--14]{DF}, \cite[Ch.~VIII]{Lang}.
 
 \subsection{Normal extensions}
@@ -33,11 +56,30 @@ For algebraic $E/F$ the following are equivalent:
 \item every $F$-embedding $\sigma:E\hookrightarrow\overline{F}$ satisfies $\sigma(E)=E$.
 \end{enumerate}
 \end{theorem}
+\begin{proof}
+(a)$\Rightarrow$(b): If $E/F$ is normal, take the family of irreducible
+polynomials in $F[x]$ having a root in $E$; $E$ is a splitting field for this
+family.
+
+(b)$\Rightarrow$(c): If $E$ is a splitting field of polynomials in $F[x]$, any
+$F$-embedding $\sigma$ permutes their roots, so $\sigma(E)=E$.
+
+(c)$\Rightarrow$(a): Let $f\in F[x]$ be irreducible with a root $\alpha$ in $E$.
+For any other root $\beta$, there is an $F$-embedding sending $\alpha$ to
+$\beta$, hence $\beta\in E$. Thus $f$ splits over $E$, so $E/F$ is normal.
+\end{proof}
 
 \subsection{Primitive element theorem}
 \begin{theorem}[Primitive element]\label{thm:PET}
 If $E/F$ is finite and separable then $E=F(\alpha)$ for some $\alpha\in E$.
 \end{theorem}
+\begin{proof}
+Take $E=F(\alpha,\beta)$. For distinct embeddings $\sigma\ne\tau$ of $E$ fixing
+$F$, the set of $c\in F$ with $\sigma(\alpha+c\beta)=\tau(\alpha+c\beta)$ is
+finite. Choose $c$ avoiding all these finitely many values. Then the conjugates
+of $\gamma=\alpha+c\beta$ are distinct, so the minimal polynomial of $\gamma$ has
+degree $[E\!:\!F]$, giving $E=F(\gamma)$.
+\end{proof}
 \begin{example}
 $\Q(\sqrt2,\sqrt3)=\Q(\sqrt2+\sqrt3)$ since the extension is finite and separable.
 \end{example}

--- a/sections/sec06-galois-fundamental-theorem.tex
+++ b/sections/sec06-galois-fundamental-theorem.tex
@@ -9,9 +9,23 @@ A finite extension $E/F$ is \emph{Galois} if it is normal and separable. Its Gal
 \begin{theorem}[Artin]
 If $G$ is a finite group of $F$-automorphisms of $E$, then $E/E^G$ is Galois and $\Gal(E/E^G)\cong G$.
 \end{theorem}
+\begin{proof}
+Let $K=E^G$. For $\alpha\in E$ set
+\(f_\alpha(x)=\prod_{\sigma\in G}(x-\sigma(\alpha))\in K[x]\). The roots of
+$f_\alpha$ lie in $E$ and are distinct, so $E/K$ is normal and separable, hence
+Galois. The inclusion $G\subseteq\Gal(E/K)$ is clear. Conversely, if
+$\tau\in\Gal(E/K)$, then $\tau(\alpha)$ is a root of $f_\alpha$ for every
+$\alpha$, so $\tau$ agrees with some $\sigma\in G$ on generators of $E$, forcing
+$\tau=\sigma$. Thus $\Gal(E/K)=G$.
+\end{proof}
 \begin{theorem}[Counting]
 For finite $E/F$, $\#\Aut_F(E)\le [E\!:\!F]$, with equality iff $E/F$ is Galois.
 \end{theorem}
+\begin{proof}
+Let $G=\Aut_F(E)$ and $K=E^G$. By Artin's theorem, $E/K$ is Galois and
+$[E\!:\!K]=\#G$. Since $F\subseteq K$, we have $[E\!:\!F]\ge [E\!:\!K]=\#G$.
+Equality holds precisely when $K=F$, i.e. when $E/F$ is Galois.
+\end{proof}
 
 \subsection{Fundamental Theorem of Galois Theory}
 \begin{theorem}\label{thm:FTGT}
@@ -25,8 +39,16 @@ yield inverse inclusion-reversing bijections between intermediate fields $F\subs
 \]
 and $K/F$ is normal $\iff$ $H\trianglelefteq G$, in which case $\Gal(K/F)\cong G/H$.
 \end{theorem}
-\begin{proof}[Idea]
-Use $E^H$ and Artin's theorem; show the correspondences are inverse and respect indices by orbit–stabilizer. Details in \cite[\S14]{DF}, \cite[Ch.~VI]{Artin}.
+\begin{proof}
+For $K$ with $F\subseteq K\subseteq E$, Artin's theorem gives $E^{\Gal(E/K)}=K$.
+For $H\le G$, the same theorem yields $\Gal(E/E^H)=H$. These equalities show the
+maps are inverse and inclusion reversing. Furthermore,
+$[E\!:\!K]=\#\Gal(E/K)=\#H$ and $[K\!:\!F]=\#G/\#H$.
+
+If $H\trianglelefteq G$ then conjugation by $G$ preserves $H$, so automorphisms
+of $E$ descend to $K=E^H$, giving $\Gal(K/F)\cong G/H$. Conversely, if $K/F$ is
+normal, any $\sigma\in G$ sends $K$ to itself, hence $\sigma H\sigma^{-1}=H$ and
+$H\trianglelefteq G$.
 \end{proof}
 
 \subsection{Examples}


### PR DESCRIPTION
## Summary
- add plain proofs for splitting fields, algebraic closures, and separability preview
- supply automorphism bound, separability and normality criteria, and primitive element proofs
- prove Artin's theorem, counting result, and the Fundamental Theorem of Galois Theory

## Checklist
- [x] Section 3: existence/uniqueness of splitting fields
- [x] Section 3: algebraic closure existence and uniqueness
- [x] Section 3: embedding bound preview
- [x] Section 4: automorphism bound (Thm. \ref{thm:autobound})
- [x] Section 5: multiplicity criterion
- [x] Section 5: separability criteria (Thm. \ref{thm:sep-criteria})
- [x] Section 5: perfect fields corollary
- [x] Section 5: normal extension characterizations (Thm. \ref{thm:normal})
- [x] Section 5: primitive element theorem (Thm. \ref{thm:PET})
- [x] Section 6: Artin's theorem
- [x] Section 6: counting theorem
- [x] Section 6: Fundamental Theorem of Galois Theory (Thm. \ref{thm:FTGT})


------
https://chatgpt.com/codex/tasks/task_e_68a016eb65cc8331baeed7bc38f32c3c