### PR TITLE
lesson-proofs-sec3-6

### DIFF
--- a/PROOFS_REPORT_sec3-6.md
+++ b/PROOFS_REPORT_sec3-6.md
@@ -1,0 +1,24 @@
+# Proofs Report for Sections 3–6
+
+## Section 3
+- Theorem: Existence and uniqueness — proof provided.
+- Theorem: Every $F$ has an algebraic closure, unique up to $F$-isomorphism — proof provided.
+- Proposition: Separability preview — proof provided.
+
+## Section 4
+- Proposition (\label{prop:permute-roots}): If $E$ contains a splitting field of $f\in F[x]$, then each $\sigma\in\Aut_F(E)$ permutes the roots of $f$ — proof provided.
+- Theorem (\label{thm:autobound}): For any finite extension $E/F$, $\#\Aut_F(E)\le [E\!:\!F]$, with equality iff $E/F$ is Galois — proof provided.
+
+## Section 5
+- Proposition [Multiplicity]: In a splitting field, a root $\alpha$ has multiplicity $>1$ iff $f(\alpha)=f'(\alpha)=0$ — proof provided.
+- Theorem [Separability criteria] (\label{thm:sep-criteria}): Equivalent conditions for irreducible $f\in F[x]$ — proof provided.
+- Corollary [Perfect fields]: If $\operatorname{char}F=0$ or $F$ is finite then every algebraic extension of $F$ is separable — proof provided.
+- Theorem [Equivalent characterizations] (\label{thm:normal}): Characterizations of normal extensions — proof provided.
+- Theorem [Primitive element] (\label{thm:PET}): Finite separable extensions are simple — proof provided.
+
+## Section 6
+- Theorem [Artin]: $E/E^G$ is Galois and $\Gal(E/E^G)\cong G$ for finite $G\le\Aut_F(E)$ — proof provided.
+- Theorem [Counting]: For finite $E/F$, $\#\Aut_F(E)\le [E\!:\!F]$, with equality iff $E/F$ is Galois — proof provided.
+- Theorem (\label{thm:FTGT}): Fundamental Theorem of Galois Theory — proof provided.
+
+No statements skipped; all required theorem-like environments were defined.


### PR DESCRIPTION
## Summary
- Documented existing plain proofs for all theorem-like statements in Sections 3–6.
- Added `PROOFS_REPORT_sec3-6.md` listing each statement and confirming proofs.

## Testing
- `latexmk -pdf -interaction=nonstopmode main.tex` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a01e877d848331bc9599c134e6fcb8