### PR TITLE
decolorize: keep boxes only for theorems/propositions

### DIFF
--- a/DEBOX_REPORT.md
+++ b/DEBOX_REPORT.md
@@ -1,0 +1,37 @@
+# Debox Report
+
+The following table summarizes environment conversions after removing color boxes. Counts reflect occurrences per file.
+
+| File | Definitions | Examples | Remarks | Lemmas | Corollaries | Theorems (boxed) | Propositions (boxed) |
+|---|---|---|---|---|---|---|---|
+| examples/section-1-examples.tex | 0 | 10 | 0 | 0 | 0 | 0 | 0 |
+| examples/section-10-examples.tex | 0 | 10 | 0 | 0 | 0 | 0 | 0 |
+| examples/section-11-examples.tex | 0 | 10 | 0 | 0 | 0 | 0 | 0 |
+| examples/section-12-examples.tex | 0 | 10 | 0 | 0 | 0 | 0 | 0 |
+| examples/section-13-examples.tex | 0 | 10 | 0 | 0 | 0 | 0 | 0 |
+| examples/section-14-examples.tex | 0 | 10 | 0 | 0 | 0 | 0 | 0 |
+| examples/section-2-examples.tex | 0 | 10 | 0 | 0 | 0 | 0 | 0 |
+| examples/section-3-examples.tex | 0 | 10 | 0 | 0 | 0 | 0 | 0 |
+| examples/section-4-examples.tex | 0 | 10 | 0 | 0 | 0 | 0 | 0 |
+| examples/section-5-examples.tex | 0 | 10 | 0 | 0 | 0 | 0 | 0 |
+| examples/section-6-examples.tex | 0 | 10 | 0 | 0 | 0 | 0 | 0 |
+| examples/section-7-examples.tex | 0 | 10 | 0 | 0 | 0 | 0 | 0 |
+| examples/section-8-examples.tex | 0 | 10 | 0 | 0 | 0 | 0 | 0 |
+| examples/section-9-examples.tex | 0 | 10 | 0 | 0 | 0 | 0 | 0 |
+| sections/100-worked-examples.tex | 0 | 100 | 0 | 0 | 0 | 0 | 0 |
+| sections/sec01-fields-polynomials.tex | 2 | 1 | 1 | 0 | 1 | 1 | 4 |
+| sections/sec02-extensions-minimal.tex | 3 | 2 | 1 | 0 | 0 | 1 | 1 |
+| sections/sec03-splitting-algebraic-closure.tex | 2 | 2 | 1 | 0 | 0 | 2 | 1 |
+| sections/sec04-automorphisms-fixedfields.tex | 2 | 2 | 0 | 0 | 0 | 1 | 1 |
+| sections/sec05-separable-normal.tex | 2 | 1 | 0 | 0 | 1 | 3 | 1 |
+| sections/sec06-galois-fundamental-theorem.tex | 1 | 2 | 0 | 0 | 0 | 3 | 0 |
+| sections/sec07-finite-fields.tex | 1 | 1 | 0 | 0 | 0 | 3 | 2 |
+| sections/sec08-cyclotomic-kummer.tex | 2 | 0 | 1 | 0 | 0 | 3 | 0 |
+| sections/sec09-solvability-radicals-quintic.tex | 2 | 0 | 0 | 0 | 0 | 2 | 1 |
+| sections/sec10-worked-examples.tex | 0 | 6 | 0 | 0 | 0 | 0 | 0 |
+| sections/sec11-infinite-galois.tex | 1 | 2 | 0 | 0 | 0 | 2 | 0 |
+| sections/sec12-constructible-geometry.tex | 1 | 1 | 0 | 0 | 2 | 2 | 0 |
+
+No Lemma environments were found, and all Theorem and Proposition instances remain boxed.
+
+No unresolved edge cases were identified.

--- a/main.tex
+++ b/main.tex
@@ -40,11 +40,11 @@
   colframe=blue!75!black,
   fonttitle=\bfseries
 }
-\tcolorboxenvironment{lemma}{
-  colback=green!5!white,
-  colframe=green!60!black,
-  fonttitle=\bfseries
-}
+%\tcolorboxenvironment{lemma}{
+%  colback=green!5!white,
+%  colframe=green!60!black,
+%  fonttitle=\bfseries
+%}
 \tcolorboxenvironment{proposition}{
   enhanced,
   colback=Magenta!5!white,
@@ -54,30 +54,30 @@
   fonttitle=\bfseries\sffamily,
   fontupper=\sffamily
 }
-\tcolorboxenvironment{corollary}{
-  colback=orange!10!white,
-  colframe=orange!70!black,
-  fonttitle=\bfseries
-}
-\tcolorboxenvironment{definition}{
-  colback=yellow!10!white,
-  colframe=yellow!60!black,
-  fonttitle=\bfseries
-}
-\tcolorboxenvironment{example}{
-  colback=teal!5!white,
-  colframe=teal!60!black,
-  fonttitle=\bfseries
-}
-\tcolorboxenvironment{remark}{
-  enhanced,
-  colback=Yellow!5!white,
-  colframe=OrangeRed!80!black,
-  colbacktitle=OrangeRed!80!black,
-  coltitle=white,
-  fonttitle=\bfseries\itshape,
-  fontupper=\itshape
-}
+%\tcolorboxenvironment{corollary}{
+%  colback=orange!10!white,
+%  colframe=orange!70!black,
+%  fonttitle=\bfseries
+%}
+%\tcolorboxenvironment{definition}{
+%  colback=yellow!10!white,
+%  colframe=yellow!60!black,
+%  fonttitle=\bfseries
+%}
+%\tcolorboxenvironment{example}{
+%  colback=teal!5!white,
+%  colframe=teal!60!black,
+%  fonttitle=\bfseries
+%}
+%\tcolorboxenvironment{remark}{
+%  enhanced,
+%  colback=Yellow!5!white,
+%  colframe=OrangeRed!80!black,
+%  colbacktitle=OrangeRed!80!black,
+%  coltitle=white,
+%  fonttitle=\bfseries\itshape,
+%  fontupper=\itshape
+%}
 % ---------- End colored boxes ----------
 
 % ---------- Shortcuts ----------


### PR DESCRIPTION
## Summary
- remove tcolorbox styling for all environments except theorem and proposition
- add deboxing report with counts per file

## Testing
- `latexmk -pdf -interaction=nonstopmode main.tex` *(fails: latexmk not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a022295a888331a59a5b0f9633a7cf